### PR TITLE
Add support for 1.8.7

### DIFF
--- a/corefoundation.gemspec
+++ b/corefoundation.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/fcheung/corefoundation}
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.8.10}
-  s.summary = %q{Ruby wrapper for  OS X's corefoundation}  
-  s.required_ruby_version = '>= 1.9.2'
+  s.summary = %q{Ruby wrapper for OS X corefoundation}  
+  s.required_ruby_version = '>= 1.8.7'
 
   s.add_runtime_dependency "ffi"
   s.add_development_dependency "rspec", "~>2.10"

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -1,4 +1,6 @@
 require 'ffi'
+require 'iconv' if RUBY_VERSION < "1.9"
+
 require 'corefoundation/base'
 require 'corefoundation/null'
 require 'corefoundation/string'

--- a/lib/corefoundation/data.rb
+++ b/lib/corefoundation/data.rb
@@ -23,7 +23,11 @@ module CF
     # @return [String]
     def to_s
       ptr = CF.CFDataGetBytePtr(self)
-      ptr.read_string(CF.CFDataGetLength(self)).force_encoding(Encoding::ASCII_8BIT)
+      if CF::String::HAS_ENCODING
+        ptr.read_string(CF.CFDataGetLength(self)).force_encoding(Encoding::ASCII_8BIT)
+      else
+        ptr.read_string(CF.CFDataGetLength(self))
+      end
     end
 
     # The size in bytes of the CFData

--- a/lib/corefoundation/extensions.rb
+++ b/lib/corefoundation/extensions.rb
@@ -50,12 +50,30 @@ class String
   # 
   # @return [CF::String, CF::Data]
   def to_cf
-    if encoding == Encoding::ASCII_8BIT
-      CF::Data.from_string self
+    if defined? encoding
+      if encoding == Encoding::ASCII_8BIT
+        CF::Data.from_string self
+      else
+        CF::String.from_string self
+      end
     else
-      CF::String.from_string self
+      begin
+        ::Iconv.conv('UTF-8', 'UTF-8', self)
+        CF::String.from_string self
+      rescue Iconv::IllegalSequence => e
+        CF::Data.from_string self
+      end
     end
   end
+
+  def to_cf_string
+    CF::String.from_string self
+  end
+  
+  def to_cf_data
+    CF::Data.from_string self
+  end
+  
 end
 
 # Ruby Time class

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -7,7 +7,9 @@ describe CF::Data do
     it 'should return a binary ruby string' do
       ruby_string = subject.to_s
       ruby_string.should == 'A CF string'
-      ruby_string.encoding.should == Encoding::ASCII_8BIT
+      if CF::String::HAS_ENCODING
+        ruby_string.encoding.should == Encoding::ASCII_8BIT
+      end
     end
   end
 
@@ -20,7 +22,9 @@ describe CF::Data do
   describe 'to_ruby' do
     it 'should behave like to_s' do
       subject.to_ruby.should == 'A CF string'
-      subject.to_ruby.encoding.should == Encoding::ASCII_8BIT
+      if 'A CF string'.respond_to? "encoding"
+        subject.to_ruby.encoding.should == Encoding::ASCII_8BIT
+      end
     end
   end
 end

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -15,13 +15,17 @@ describe 'extensions' do
 
   context 'with a 8bit string' do
     it 'should return a cf data' do
-      '123'.encode(Encoding::ASCII_8BIT).to_cf.should be_a(CF::Data)
+      if CF::String::HAS_ENCODING
+        '123'.encode(Encoding::ASCII_8BIT).to_cf.should be_a(CF::Data)
+      end
+      '123'.to_cf_data.should be_a(CF::Data)
     end
   end
 
   context 'with an asciistring' do
     it 'should return a cf string' do
       '123'.to_cf.should be_a(CF::String)
+      '123'.to_cf_string.should be_a(CF::String)
     end
   end
 

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'spec_helper'
 
 describe 'extensions' do
@@ -14,18 +15,56 @@ describe 'extensions' do
   end
 
   context 'with a 8bit string' do
+    it 'should be binary' do
+      '123'.binary!.binary?.should be_true
+      if CF::String::HAS_ENCODING
+        '123'.encode(Encoding::ASCII_8BIT).binary?.should be_true
+      else
+        "\xff\xff\xff".binary?.should be_true
+      end
+      [0xff, 0xff, 0xff].pack("C*").binary?.should be_true
+    end
+
     it 'should return a cf data' do
       if CF::String::HAS_ENCODING
         '123'.encode(Encoding::ASCII_8BIT).to_cf.should be_a(CF::Data)
       end
-      '123'.to_cf_data.should be_a(CF::Data)
+      '123'.binary!.to_cf.should be_a(CF::Data)
+      [0xff, 0xff, 0xff].pack("C*").to_cf.should be_a(CF::Data)
     end
+
+    it 'should return nil on garbage binary data flagged as text' do
+      [0xff, 0xff, 0xff].pack("C*").binary!(false).to_cf.should be_nil
+    end
+
+    # the word "über" in utf-8
+    uber = [195, 188, 98, 101, 114]
+    it 'should convert utf-8 to cf string' do
+      uber.pack("C*").binary!(false).to_cf.should be_a(CF::String)
+      if CF::String::HAS_ENCODING
+        uber.pack("C*").force_encoding("UTF-8").to_cf.should be_a(CF::String)
+      end
+    end
+    it 'should convert utf-8 flagged as binary to cf data' do
+      uber.pack("C*").binary!.to_cf.should be_a(CF::Data)
+    end
+
   end
 
   context 'with an asciistring' do
+    it 'should be non-binary' do
+      '123'.binary?.should be_false
+    end
+    it 'can round-trip' do
+      '123'.binary!(true).binary!(false).binary?.should be_false
+    end
     it 'should return a cf string' do
       '123'.to_cf.should be_a(CF::String)
       '123'.to_cf_string.should be_a(CF::String)
+    end
+    it 'should return cf data if asked nicely' do
+      '123'.to_cf_data.should be_a(CF::Data)
+      '123'.binary!.to_cf.should be_a(CF::Data)
     end
   end
 

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -9,10 +9,14 @@ describe CF::String do
 
     # The intent is to force feed CF::String with an invalid utf-8 string
     # but jruby doesn't seem to allow this to be constructed
-    unless RUBY_ENGINE == 'jruby'
+    unless defined? RUBY_ENGINE and RUBY_ENGINE == 'jruby'
       context 'with invalid data' do
         it 'returns nil' do
-          CF::String.from_string("\xff\xff\xff".force_encoding('UTF-8')).should be_nil
+          if CF::String::HAS_ENCODING
+            CF::String.from_string("\xff\xff\xff".force_encoding('UTF-8')).should be_nil
+          else
+            CF::String.from_string("\xff\xff\xff").should be_nil
+          end
         end
       end
     end
@@ -22,14 +26,19 @@ describe CF::String do
     it 'should return a utf ruby string' do
       ruby_string = CF::String.from_string('A CF string').to_s
       ruby_string.should == 'A CF string'
-      ruby_string.encoding.should == Encoding::UTF_8
+      if CF::String::HAS_ENCODING
+        ruby_string.encoding.should == Encoding::UTF_8
+      else
+      end
     end
   end
 
   describe 'to_ruby' do
     it 'should behave like to_s' do
       CF::String.from_string('A CF string').to_ruby.should == 'A CF string'
-      CF::String.from_string('A CF string').to_ruby.encoding.should == Encoding::UTF_8
+      if CF::String::HAS_ENCODING
+        CF::String.from_string('A CF string').to_ruby.encoding.should == Encoding::UTF_8
+      end
     end
   end
 


### PR DESCRIPTION
Pre-1.9, String doesn't have any notion of encoding, it's all just bytes.  Uses Iconv where appropriate to ensure valid UTF-8 encoding.  Iconv doesn't get pulled in for 1.9+, because it's not always safe to assume it's present.  For the simple case of the vendor Ruby, however, it is present.
