### PR TITLE
POC: Expose preferences utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+CoreFoundation
+==============
+
+FFI based wrappers for a subset of core foundation: various bits of CFString, CFData, CFArray, CFDictionary are available.
+
+Although the CF collection classes can store arbitrary pointer sized values this wrapper only supports storing CFTypes.
+
+The CF namespace has the raw FFI generated method calls but it's usually easier to use the wrapper classes: `CF::String`, `CF::Date`, `CF::Array`, `CF::Dictionary`, `CF::Boolean` which try to present a rubyish view of the world (for example `CF::Array` implements `Enumerable`)
+
+These implement methods for creating new instances from ruby objects (eg `CF::String.from_string("hello world")`) but you can also pass build them from an `FFI::Pointer`).
+
+Preferences interface
+==============
+
+Preferences interface wraps CoreFoundation's [preference utilities](https://developer.apple.com/documentation/corefoundation/preferences_utilities) and provide functionality for managing preferences across domains.
+
 Setup
 =============
 1. Add `gem 'corefoundation', git: "https://github.com/chef/corefoundation.git"` to your gemfile
@@ -19,17 +35,6 @@ CF::Preferences.get(key, domain, CF::Preferences::CURRENT_USER, CF::Preferences:
 CF::Preferences.set(key, value, domain, 'example_username', 'example.host')
 CF::Preferences.set(key, value, domain, CF::Preferences::ALL_USERS, CF::Preferences::ALL_HOSTS)
 ```
-
-CoreFoundation
-==============
-
-FFI based wrappers for a subset of core foundation: various bits of CFString, CFData, CFArray, CFDictionary are available. Not that useful on its own but a useful building block for writing ffi wrappers of other OS X libraries.
-
-Although the CF collection classes can store arbitrary pointer sized values this wrapper only supports storing CFTypes.
-
-The CF namespace has the raw FFI generated method calls but it's usually easier to use the wrapper classes: `CF::String`, `CF::Date`, `CF::Array`, `CF::Dictionary`, `CF::Boolean` which try to present a rubyish view of the world (for example `CF::Array` implements `Enumerable`)
-
-These implement methods for creating new instances from ruby objects (eg `CF::String.from_string("hello world")`) but you can also pass build them from an `FFI::Pointer`).
 
 Converting
 ===========

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
-[![Build Status](https://travis-ci.org/fcheung/corefoundation.png)](https://travis-ci.org/fcheung/corefoundation)
+Setup
+=============
+1. Add `gem 'corefoundation', git: "https://github.com/chef/corefoundation.git"` to your gemfile
+2. `bundle install`
+
+Usage
+=============
+```ruby
+domain = "NSGlobalDomain"
+key = "com.apple.securitypref.logoutvalue"
+value = 3150
+
+# Getting preferences
+CF::Preferences.get(key, domain)
+CF::Preferences.get(key, domain, 'example_username', 'example.host')
+CF::Preferences.get(key, domain, CF::Preferences::CURRENT_USER, CF::Preferences::CURRENT_HOST)
+
+# Setting preferences
+CF::Preferences.set(key, value, domain, 'example_username', 'example.host')
+CF::Preferences.set(key, value, domain, CF::Preferences::ALL_USERS, CF::Preferences::ALL_HOSTS)
+```
 
 CoreFoundation
 ==============

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -11,3 +11,6 @@ require 'corefoundation/dictionary'
 require 'corefoundation/number'
 require 'corefoundation/date'
 require 'corefoundation/extensions'
+
+# Utilities
+require 'corefoundation/preferences'

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -1,6 +1,7 @@
 require 'ffi'
 require 'iconv' if RUBY_VERSION < "1.9"
 
+# CF Types
 require 'corefoundation/base'
 require 'corefoundation/null'
 require 'corefoundation/string'
@@ -11,6 +12,9 @@ require 'corefoundation/dictionary'
 require 'corefoundation/number'
 require 'corefoundation/date'
 require 'corefoundation/extensions'
+
+# Error wrapper
+require 'corefoundation/error'
 
 # Utilities
 require 'corefoundation/preferences'

--- a/lib/corefoundation/error.rb
+++ b/lib/corefoundation/error.rb
@@ -1,0 +1,5 @@
+module CF
+  class Error < StandardError
+    # TODO: add context to messages
+  end
+end

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -14,19 +14,12 @@ module CF
   class Preferences
     class << self
       def get(key, application_id)
-        plist_ref = CF.CFPreferencesCopyAppValue(
-          key.to_cf,
-          application_id.to_cf
-        )
+        plist_ref = CF.CFPreferencesCopyAppValue(key.to_cf, application_id.to_cf)
         CF::Base.typecast(plist_ref).to_ruby
       end
 
       def set(key, value, application_id)
-        CF.CFPreferencesSetAppValue(
-          key.to_cf,
-          value.to_cf,
-          application_id.to_cf
-        )
+        CF.CFPreferencesSetAppValue(key.to_cf, value.to_cf, application_id.to_cf)
         CF.CFPreferencesAppSynchronize(application_id.to_cf)
       end
     end

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -1,0 +1,34 @@
+# Maps Preferences Utilities
+# Documentation at https://developer.apple.com/documentation/corefoundation/preferences_utilities
+
+module CF
+  typedef :pointer, :cfpropertylistref
+  typedef :cfstringref, :key
+  typedef :cfstringref, :application_id
+  typedef :cfpropertylistref, :value
+
+  attach_function 'CFPreferencesCopyAppValue', [:key, :application_id], :cfpropertylistref
+  attach_function 'CFPreferencesSetAppValue', [:key, :value, :application_id], :void
+  attach_function 'CFPreferencesAppSynchronize', [:application_id], :bool
+
+  class Preferences
+    class << self
+      def get(key, application_id)
+        plist_ref = CF.CFPreferencesCopyAppValue(
+          key.to_cf,
+          application_id.to_cf
+        )
+        CF::Base.typecast(plist_ref).to_ruby
+      end
+
+      def set(key, value, application_id)
+        CF.CFPreferencesSetAppValue(
+          key.to_cf,
+          value.to_cf,
+          application_id.to_cf
+        )
+        CF.CFPreferencesAppSynchronize(application_id.to_cf)
+      end
+    end
+  end
+end

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -5,22 +5,65 @@ module CF
   typedef :pointer, :cfpropertylistref
   typedef :cfstringref, :key
   typedef :cfstringref, :application_id
+  typedef :cfstringref, :username
+  typedef :cfstringref, :hostname
   typedef :cfpropertylistref, :value
 
+  attach_variable 'kCFPreferencesCurrentUser', :cfstringref
+  attach_variable 'kCFPreferencesAnyUser', :cfstringref
+  attach_variable 'kCFPreferencesCurrentHost', :cfstringref
+  attach_variable 'kCFPreferencesAnyHost', :cfstringref
+  attach_variable 'kCFPreferencesAnyApplication', :cfstringref
+
   attach_function 'CFPreferencesCopyAppValue', [:key, :application_id], :cfpropertylistref
+  attach_function 'CFPreferencesCopyValue', [:key, :application_id, :username, :hostname], :cfpropertylistref
+  attach_function 'CFPreferencesCopyKeyList', [:application_id, :username, :hostname], :cfarrayref
+
   attach_function 'CFPreferencesSetAppValue', [:key, :value, :application_id], :void
+  attach_function 'CFPreferencesSetValue', [:key, :value, :application_id, :username, :hostname], :void
   attach_function 'CFPreferencesAppSynchronize', [:application_id], :bool
 
   class Preferences
+    CURRENT_USER = CF.kCFPreferencesCurrentUser
+    ALL_USERS = CF.kCFPreferencesAnyUser
+    CURRENT_HOST = CF.kCFPreferencesCurrentHost
+    ALL_HOSTS = CF.kCFPreferencesAnyHost
+
     class << self
-      def get(key, application_id)
-        plist_ref = CF.CFPreferencesCopyAppValue(key.to_cf, application_id.to_cf)
-        CF::Base.typecast(plist_ref).to_ruby
+      def get(key, application_id, username = nil, hostname = nil)
+        # TODO: Check usecase for `CFPreferencesCopyAppValue`
+
+        plist_ref = if username && hostname
+                      CF.CFPreferencesCopyValue(key.to_cf, application_id.to_cf, arg_to_cf(username), arg_to_cf(hostname))
+                    else
+                      CF.CFPreferencesCopyAppValue(key.to_cf, application_id.to_cf)
+                    end
+        CF::Base.typecast(plist_ref).to_ruby unless plist_ref.null?
       end
 
-      def set(key, value, application_id)
-        CF.CFPreferencesSetAppValue(key.to_cf, value.to_cf, application_id.to_cf)
+      def get!(key, application_id, username = nil, hostname = nil)
+        get(key, application_id, username, hostname) || (raise CF::Error, "Preference key `#{key}` not found")
+      end
+
+      def set(key, value, application_id, username = CURRENT_USER, hostname = CURRENT_HOST)
+        CF.CFPreferencesSetValue(key.to_cf, value.to_cf, application_id.to_cf, arg_to_cf(username), arg_to_cf(hostname))
         CF.CFPreferencesAppSynchronize(application_id.to_cf)
+      end
+
+      def list_keys(application_id, username, hostname)
+        arr_ref = CF.CFPreferencesCopyKeyList(
+          application_id.to_cf,
+          arg_to_cf(username),
+          arg_to_cf(hostname)
+        )
+        CF::Array.new(arr_ref).to_ruby
+      end
+
+      private
+
+      # Check for constants CURRENT_USER, ALL_HOSTS etc.
+      def arg_to_cf(arg)
+        arg.respond_to?(:to_cf) ? arg.to_cf : arg
       end
     end
   end


### PR DESCRIPTION
Expose preferences utility functions for basic usage in `macos_userdefaults`
**Note**: This is a POC, not meant for production usage yet.

## Description
Expose [preferences_utilities](https://developer.apple.com/documentation/corefoundation/preferences_utilities) meant for accessing/modifying app preferences on osx via `macos_userdefaults` resource in chef

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
TODO

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
