### PR TITLE
Add interface to preference utilities

### DIFF
--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -11,6 +11,7 @@ require_relative "corefoundation/dictionary"
 require_relative "corefoundation/number"
 require_relative "corefoundation/date"
 
+require_relative "corefoundation/exceptions"
 require_relative "corefoundation/extensions"
 require_relative "corefoundation/preferences"
 

--- a/lib/corefoundation/exceptions.rb
+++ b/lib/corefoundation/exceptions.rb
@@ -6,5 +6,11 @@ module CF
         super("Returned NULL value for \"#{key}\" in \"#{domain}\", hostname: #{hostname}")
       end
     end
+    # Raised when the preference value failed to write.
+    class PreferenceSyncFailed < RuntimeError
+      def initialize(key, domain, hostname)
+        super("Couldn't write preference value for \"#{key}\" in \"#{domain}\", hostname: #{hostname}")
+      end
+    end
   end
 end

--- a/lib/corefoundation/exceptions.rb
+++ b/lib/corefoundation/exceptions.rb
@@ -1,0 +1,10 @@
+module CF
+  module Exceptions
+    # Raised when the preference value couldn't be found for a domain.
+    class PreferenceDoesNotExist < RuntimeError
+      def initialize(key, domain, hostname)
+        super("Returned NULL value for \"#{key}\" in \"#{domain}\", hostname: #{hostname}")
+      end
+    end
+  end
+end

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -102,40 +102,6 @@ module CF
       raise(CF::Exceptions::PreferenceSyncFailed.new(key, application_id, hostname)) unless set(key, value, application_id, username, hostname)
     end
 
-    # Checks whether a key exists in the preference domain. It'll also return false for an invalid domain.
-    #
-    # @param [String] key Preference key to read
-    # @param [String] application_id Preference domain for the key
-    # @param [String, Symbol] username Domain user (current, any or a specific user)
-    # @param [String, Symbol] hostname Hostname (current, all hosts or a specific host)
-    #
-    # @return [TrueClass, FalseClass] Return true or false to indicate if it is a valid key.
-    #
-    def self.valid_key?(key, application_id, username = nil, hostname = nil)
-      domain_keys = list_keys(application_id, username, hostname)
-      domain_keys.include?(key)
-    end
-
-    # Get all existing keys for a preference domain.
-    #
-    # @param [String] application_id Preference domain for the key
-    # @param [String, Symbol] username Domain user (current, any or a specific user)
-    # @param [String, Symbol] hostname Hostname (current, all hosts or a specific host)
-    #
-    # @return [Array<String>] Array of key names
-    #
-    # @visiblity private
-    def self.list_keys(application_id, username = nil, hostname = nil)
-      username ||= CURRENT_USER
-      hostname ||= ALL_HOSTS
-      arr_ref = CF.CFPreferencesCopyKeyList(
-        application_id.to_cf,
-        arg_to_cf(username),
-        arg_to_cf(hostname)
-      )
-      arr_ref.null? ? [] : CF::Array.new(arr_ref).to_ruby
-    end
-
     # Convert an object from ruby to cf type.
     #
     # @param [VALUE, CFType] arg A ruby or corefoundation object.
@@ -147,6 +113,6 @@ module CF
       arg.respond_to?(:to_cf) ? arg.to_cf : arg
     end
 
-    private_class_method :list_keys, :arg_to_cf
+    private_class_method :arg_to_cf
   end
 end

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -81,7 +81,7 @@ module CF
     def self.set(key, value, application_id, username = nil, hostname = nil)
       username ||= CURRENT_USER
       hostname ||= ALL_HOSTS
-      CF.CFPreferencesSetValue(key.to_cf, value.to_cf, application_id.to_cf, arg_to_cf(username), arg_to_cf(hostname))
+      CF.CFPreferencesSetValue(key.to_cf, arg_to_cf(value), application_id.to_cf, arg_to_cf(username), arg_to_cf(hostname))
       CF.CFPreferencesAppSynchronize(application_id.to_cf)
     end
 

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -116,8 +116,6 @@ module CF
       domain_keys.include?(key)
     end
 
-    private
-
     # Get all existing keys for a preference domain.
     #
     # @param [String] application_id Preference domain for the key
@@ -148,5 +146,7 @@ module CF
     def self.arg_to_cf(arg)
       arg.respond_to?(:to_cf) ? arg.to_cf : arg
     end
+
+    private_class_method :list_keys, :arg_to_cf
   end
 end

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -94,7 +94,7 @@ module CF
     #
     # @raise [PreferenceSyncFailed] If {#self.set} call returned false.
     #
-    # @return [VALUE] Returns true if preference value is successfully written.
+    # @return [VALUE] Returns nil if preference value is successfully written.
     #
     def self.set!(key, value, application_id, username = nil, hostname = nil)
       hostname = arg_to_cf(hostname || ALL_HOSTS)

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -64,8 +64,8 @@ module CF
     def self.get!(key, application_id, username = nil, hostname = nil)
       hostname = arg_to_cf(hostname || ALL_HOSTS)
       hostname = CF::Base.typecast(hostname).to_ruby
-      get(key, application_id, username, hostname) ||
-        raise(CF::Exceptions::PreferenceDoesNotExist.new(key, application_id, hostname))
+      value = get(key, application_id, username, hostname)
+      value.nil? ? raise(CF::Exceptions::PreferenceDoesNotExist.new(key, application_id, hostname)) : value
     end
 
     # Set the value for preference domain using `CFPreferencesSetValue`.

--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -85,6 +85,23 @@ module CF
       CF.CFPreferencesAppSynchronize(application_id.to_cf)
     end
 
+    # Calls the {#self.set} method and raise a `PreferenceSyncFailed` error if `false` is returned.
+    #
+    # @param [String] key Preference key to write
+    # @param [String] application_id Preference domain for the key
+    # @param [String, Symbol] username Domain user (current, any or a specific user)
+    # @param [String, Symbol] hostname Hostname (current, all hosts or a specific host)
+    #
+    # @raise [PreferenceSyncFailed] If {#self.set} call returned false.
+    #
+    # @return [VALUE] Returns true if preference value is successfully written.
+    #
+    def self.set!(key, value, application_id, username = nil, hostname = nil)
+      hostname = arg_to_cf(hostname || ALL_HOSTS)
+      hostname = CF::Base.typecast(hostname).to_ruby
+      raise(CF::Exceptions::PreferenceSyncFailed.new(key, application_id, hostname)) unless set(key, value, application_id, username, hostname)
+    end
+
     # Checks whether a key exists in the preference domain. It'll also return false for an invalid domain.
     #
     # @param [String] key Preference key to read

--- a/spec/preferences_spec.rb
+++ b/spec/preferences_spec.rb
@@ -64,22 +64,4 @@ describe CF::Preferences do
       end
     end
   end
-
-  describe "self.valid_key?" do
-    before do
-      CF::Preferences.set!(@validKey, @value, @validDomain)
-    end
-
-    context "when called for a valid domain/default pair" do
-      it 'returns true' do
-        expect(CF::Preferences.valid_key?(@validKey, @validDomain)).to eq true
-      end
-    end
-
-    context "when called for an invalid domain/default pair" do
-      it "returns false" do
-        expect(CF::Preferences.valid_key?(@invalidKey, @validDomain)).to eq false
-      end
-    end
-  end
 end

--- a/spec/preferences_spec.rb
+++ b/spec/preferences_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+describe CF::Preferences do
+  before do
+    @validDomain = "TestValidDomain"
+    @invalidDomain = "TestInvalidDomain"
+    @validKey = "ValidTestKey"
+    @invalidKey = "InvalidTestKey"
+    @value = "TestValue"
+  end
+
+  after(:each) do
+    CF::Preferences.set!(@validKey, nil, @validDomain)
+    CF::Preferences.set!(@invalidKey, nil, @validDomain)
+  end
+
+  describe "self.set" do
+    context "when called with valid domain/default pair" do
+      it "writes correct value and returns true" do
+        expect(CF::Preferences.set(@validKey, @value, @validDomain)).to eq true
+        expect(CF::Preferences.get(@validKey, @validDomain)).to eq @value
+      end
+    end
+  end
+
+  describe "self.set!" do
+    context "when called with valid domain/default pair" do
+      it "writes correct value and returns nil" do
+        expect(CF::Preferences.set!(@validKey, @value, @validDomain)).to be_nil
+        expect(CF::Preferences.get(@validKey, @validDomain)).to eq @value
+      end
+    end
+  end
+
+  describe "self.get" do
+    before do
+      CF::Preferences.set(@validKey, @value, @validDomain)
+    end
+
+    context "when called with valid domain/default pair" do
+      it "returns value" do
+        expect(CF::Preferences.get(@validKey, @validDomain)).to eq @value
+      end
+    end
+
+    context "when called with invalid domain/default pair" do  
+      it "returns nil" do
+        expect(CF::Preferences.get(@validKey, @invalidDomain)).to be_nil
+      end
+    end
+  end
+
+  describe "self.get!" do
+    context "when called with valid domain/default pair" do
+      it "returns value" do
+        expect(CF::Preferences.set!(@validKey, @value, @validDomain)).to be_nil
+        expect(CF::Preferences.get!(@validKey, @validDomain)).to eq @value
+      end
+    end
+
+    context "when called with invalid domain/default pair" do  
+      it "raise an error" do
+        expect { CF::Preferences.get!(@validKey, @invalidDomain) }.to raise_error CF::Exceptions::PreferenceDoesNotExist
+      end
+    end
+  end
+
+  describe "self.valid_key?" do
+    before do
+      CF::Preferences.set!(@validKey, @value, @validDomain)
+    end
+
+    context "when called for a valid domain/default pair" do
+      it 'returns true' do
+        expect(CF::Preferences.valid_key?(@validKey, @validDomain)).to eq true
+      end
+    end
+
+    context "when called for an invalid domain/default pair" do
+      it "returns false" do
+        expect(CF::Preferences.valid_key?(@invalidKey, @validDomain)).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Interface to the preference utilities in the corefoundation framework. 
Official documentation for the framework: https://developer.apple.com/documentation/corefoundation/preferences_utilities

## Description
These changes focus on supporting the `macos_userdefaults` rewrite. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/10307
https://github.com/chef/desktop-config/issues/405


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
