### PR TITLE
Refactor base class to simplify and add Memory module

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  NewCops: enable
+  Exclude:
+    - '**/Gemfile'
+    - '**/Rakefile'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,2 @@
 source 'https://rubygems.org'
-
 gemspec
-
-gem 'rake', '< 11.0' # required until we bump rspec to 3.x

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-CoreFoundation
-==============
+# CoreFoundation
 
 FFI based wrappers for a subset of core foundation: various bits of CFString, CFData, CFArray, CFDictionary are available.
 
@@ -9,18 +8,17 @@ The CF namespace has the raw FFI generated method calls but it's usually easier 
 
 These implement methods for creating new instances from ruby objects (eg `CF::String.from_string("hello world")`) but you can also pass build them from an `FFI::Pointer`).
 
-Preferences interface
-==============
+## Setup
 
-Preferences interface wraps CoreFoundation's [preference utilities](https://developer.apple.com/documentation/corefoundation/preferences_utilities) and provide functionality for managing preferences across domains.
-
-Setup
-=============
 1. Add `gem 'corefoundation', git: "https://github.com/chef/corefoundation.git"` to your gemfile
 2. `bundle install`
 
-Usage
-=============
+## Usage
+
+### Preferences interface
+
+Preferences interface wraps CoreFoundation's [preference utilities](https://developer.apple.com/documentation/corefoundation/preferences_utilities) and provide functionality for managing preferences across domains.
+
 ```ruby
 domain = "NSGlobalDomain"
 key = "com.apple.securitypref.logoutvalue"
@@ -36,8 +34,7 @@ CF::Preferences.set(key, value, domain, 'example_username', 'example.host')
 CF::Preferences.set(key, value, domain, CF::Preferences::ALL_USERS, CF::Preferences::ALL_HOSTS)
 ```
 
-Converting
-===========
+### Converting
 
 `CF::Base` objects has a `to_ruby` that creates a ruby object of the most approprite type (`String` for `CF::String`, `Time` for `CF::Date`, `Integer` or `Float` for `CF::Number` etc). The collection classes call `to_ruby` on their contents too.
 
@@ -45,11 +42,11 @@ In addition to the methods on the wrapper classes themselves, the ruby classes a
 
 If you have an `FFI::Pointer` or a raw address then you can create a wrapper by passing it to `new`, for example `CF::String.new(some_pointer)`. This does *not* check that the pointer is actually a `CFString`. You can use `CF::Base.typecast` to construct an instance of the appropriate subclass, for example `CF::Base.typecast(some_pointer)` would return a `CF::String` if `some_pointer` was in fact a `CFStringRef`.
 
-## Memory Management
+### Memory Management
 
 The convenience methods for creating CF objects will release the cf object when they are garbage collected. Methods on the convenience classes will usually retain the result and mark it for releasing when they are garbage collected (for example `CF::Dictionary#[]` retains the returned value). You don't need to do any extra memory management on these.
 
-If you pass an `FFI::Pointer` to `new` or `typecast` no assumptions are made for you. You should call `retain` or `release` to manage it manually. As an alternative to calling `release` manually,  the `release_on_gc` method adds a finalizer to the wrapper that will call `CFRelease` on the Core Foundation object when the wrapper is garbage collected. You will almost certainly crash your ruby interpreter if you overrelease an object and you will leak memory if you overretain one.
+If you pass an `FFI::Pointer` to `new` or `typecast` no assumptions are made for you. You should call `retain` to manage it manually. However, all objects will add a finalizer to the wrapper that will call `CFRelease` on the Core Foundation object when the wrapper is garbage collected.
 
 If you use the raw api (eg `CF.CFArrayCreate`) then you're on your own.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ These implement methods for creating new instances from ruby objects (eg `CF::St
 
 ## Setup
 
+Add this to your Gemfile
+
+```ruby
+gem 'corefoundation'
+```
+and run
+
+```bash
+bundle install
+```
+
+## Usage
+
+### Preferences interface
+
 1. Add `gem 'corefoundation', git: "https://github.com/chef/corefoundation.git"` to your gemfile
 2. `bundle install`
 

--- a/corefoundation.gemspec
+++ b/corefoundation.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6'
 
   s.add_runtime_dependency "ffi", ">= 1.15.0"
-  s.add_development_dependency "rspec", "~>2.10"
+  s.add_development_dependency "rspec", ">= 3.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "chefstyle", "2.0.7"
   s.add_development_dependency "yard"

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -12,7 +12,6 @@ require_relative 'corefoundation/dictionary'
 require_relative 'corefoundation/number'
 require_relative 'corefoundation/date'
 
-require_relative 'corefoundation/error'
 require_relative 'corefoundation/extensions'
 require_relative 'corefoundation/preferences'
 

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -33,6 +33,7 @@ require_relative 'corefoundation/data'
 require_relative 'corefoundation/dictionary'
 require_relative 'corefoundation/number'
 require_relative 'corefoundation/date'
+require_relative 'corefoundation/exceptions'
 require_relative 'corefoundation/preferences'
 require_relative 'corefoundation/extensions'
 

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -1,7 +1,10 @@
-require 'ffi'
-require 'iconv' if RUBY_VERSION < "1.9"
+# frozen_string_literal: true
 
-# CF Types
+require 'ffi'
+require 'iconv' if RUBY_VERSION < '1.9'
+
+require 'corefoundation/memory'
+require 'corefoundation/register'
 require 'corefoundation/base'
 require 'corefoundation/null'
 require 'corefoundation/string'
@@ -11,10 +14,17 @@ require 'corefoundation/data'
 require 'corefoundation/dictionary'
 require 'corefoundation/number'
 require 'corefoundation/date'
-require 'corefoundation/extensions'
 
-# Error wrapper
 require 'corefoundation/error'
-
-# Utilities
+require 'corefoundation/extensions'
 require 'corefoundation/preferences'
+
+# REVIEW: Include patches from module
+Integer.include CF::CoreExtensions::Integer
+Float.include CF::CoreExtensions::Float
+Array.include CF::CoreExtensions::Array
+TrueClass.include CF::CoreExtensions::TrueClass
+FalseClass.include CF::CoreExtensions::FalseClass
+String.include CF::CoreExtensions::String
+Time.include CF::CoreExtensions::Time
+Hash.include CF::CoreExtensions::Hash

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -1,9 +1,31 @@
 require "ffi" unless defined?(FFI)
 
+module CF
+  extend FFI::Library
+  ffi_lib '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
+
+  if FFI::Platform::ARCH == 'x86_64'
+    typedef :long_long, :cfindex
+    typedef :long_long, :cfcomparisonresult
+    typedef :ulong_long, :cfoptionflags
+    typedef :ulong_long, :cftypeid
+    typedef :ulong_long, :cfhashcode
+  else
+    typedef :long, :cfindex
+    typedef :long, :cfcomparisonresult
+    typedef :ulong, :cfoptionflags
+    typedef :ulong, :cftypeid
+    typedef :ulong, :cfhashcode
+  end
+
+  typedef :pointer, :cftyperef
+end
+
 require_relative 'corefoundation/memory'
 require_relative 'corefoundation/register'
 require_relative 'corefoundation/base'
 require_relative 'corefoundation/null'
+require_relative 'corefoundation/range'
 require_relative 'corefoundation/string'
 require_relative 'corefoundation/array'
 require_relative 'corefoundation/boolean'
@@ -11,9 +33,8 @@ require_relative 'corefoundation/data'
 require_relative 'corefoundation/dictionary'
 require_relative 'corefoundation/number'
 require_relative 'corefoundation/date'
-
-require_relative 'corefoundation/extensions'
 require_relative 'corefoundation/preferences'
+require_relative 'corefoundation/extensions'
 
 # REVIEW: Include patches from module
 Integer.include CF::CoreExtensions::Integer
@@ -24,4 +45,3 @@ FalseClass.include CF::CoreExtensions::FalseClass
 String.include CF::CoreExtensions::String
 Time.include CF::CoreExtensions::Time
 Hash.include CF::CoreExtensions::Hash
-

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -1,20 +1,20 @@
 require "ffi" unless defined?(FFI)
 
-require 'corefoundation/memory'
-require 'corefoundation/register'
-require 'corefoundation/base'
-require 'corefoundation/null'
-require 'corefoundation/string'
-require 'corefoundation/array'
-require 'corefoundation/boolean'
-require 'corefoundation/data'
-require 'corefoundation/dictionary'
-require 'corefoundation/number'
-require 'corefoundation/date'
+require_relative 'corefoundation/memory'
+require_relative 'corefoundation/register'
+require_relative 'corefoundation/base'
+require_relative 'corefoundation/null'
+require_relative 'corefoundation/string'
+require_relative 'corefoundation/array'
+require_relative 'corefoundation/boolean'
+require_relative 'corefoundation/data'
+require_relative 'corefoundation/dictionary'
+require_relative 'corefoundation/number'
+require_relative 'corefoundation/date'
 
-require 'corefoundation/error'
-require 'corefoundation/extensions'
-require 'corefoundation/preferences'
+require_relative 'corefoundation/error'
+require_relative 'corefoundation/extensions'
+require_relative 'corefoundation/preferences'
 
 # REVIEW: Include patches from module
 Integer.include CF::CoreExtensions::Integer

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -1,7 +1,4 @@
-# frozen_string_literal: true
-
-require 'ffi'
-require 'iconv' if RUBY_VERSION < '1.9'
+require "ffi" unless defined?(FFI)
 
 require 'corefoundation/memory'
 require 'corefoundation/register'

--- a/lib/corefoundation.rb
+++ b/lib/corefoundation.rb
@@ -24,3 +24,4 @@ FalseClass.include CF::CoreExtensions::FalseClass
 String.include CF::CoreExtensions::String
 Time.include CF::CoreExtensions::Time
 Hash.include CF::CoreExtensions::Hash
+

--- a/lib/corefoundation/array.rb
+++ b/lib/corefoundation/array.rb
@@ -92,7 +92,6 @@ module CF
       raise TypeError, "instance is not mutable" unless mutable?
       self.class.check_cftype(value)
       CF.CFArraySetValueAtIndex(self, index, value)
-      value
     end
 
     # Appends a value to the array

--- a/lib/corefoundation/array.rb
+++ b/lib/corefoundation/array.rb
@@ -49,7 +49,7 @@ module CF
       range[:location] = 0
       range[:length] = length
       callback = lambda do |value, _|
-        yield Base.typecast(value).retain.release_on_gc
+        yield Base.typecast(value).retain
       end
       CF.CFArrayApplyFunction(self, range, callback, nil)
       self
@@ -64,13 +64,13 @@ module CF
       end
       m = FFI::MemoryPointer.new(:pointer, array.length)
       m.write_array_of_pointer(array)
-      new(CF.CFArrayCreate(nil,m,array.length,CF::kCFTypeArrayCallBacks.to_ptr)).release_on_gc
+      new(CF.CFArrayCreate(nil,m,array.length,CF::kCFTypeArrayCallBacks.to_ptr))
     end
 
     # Creates a new, empty mutable CFArray
     # @return [CF::Array] A mutable CF::Array containing the objects, setup to release the array upon garbage collection
     def self.mutable
-      result = new(CF.CFArrayCreateMutable nil, 0, CF::kCFTypeArrayCallBacks.to_ptr).release_on_gc
+      result = new(CF.CFArrayCreateMutable nil, 0, CF::kCFTypeArrayCallBacks.to_ptr)
       result.instance_variable_set(:@mutable, true)
       result
     end
@@ -79,7 +79,7 @@ module CF
     # @param [Integer] index the 0 based index of the item to retrieve. Behaviour is undefined if it is not in the range 0...size
     # @return [CF::Base] a subclass of CF::Base
     def [](index)
-      Base.typecast(CF.CFArrayGetValueAtIndex(self, index)).retain.release_on_gc
+      Base.typecast(CF.CFArrayGetValueAtIndex(self, index)).retain
     end
 
     # Sets object at the index

--- a/lib/corefoundation/base.rb
+++ b/lib/corefoundation/base.rb
@@ -72,7 +72,7 @@ module CF
     end
 
     def to_ruby
-      raise "#{self.class} is missing an implemention for the to_ruby method."
+      raise CF::Exceptions::MethodNotImplemented, "#{self.class} should implement the to_ruby method."
     end
   end
 end

--- a/lib/corefoundation/base.rb
+++ b/lib/corefoundation/base.rb
@@ -6,9 +6,8 @@ module CF
   class Base
     include CF::Memory
     include CF::Register
-    # Allow setting the wrapper pointer. You should only do this rarely. If you have used release_on_gc then that
-    # finalizer will still be called on the original pointer value
-    attr_accessor :ptr
+
+    attr_reader :ptr
 
     # Raises an exception if the argument does not inherit from CF::Base
     #
@@ -30,6 +29,12 @@ module CF
     # @param [FFI::Pointer] pointer The pointer to wrap
     def initialize(pointer)
       @ptr = FFI::Pointer.new(pointer)
+      ObjectSpace.define_finalizer(self, self.class.finalize(ptr))
+    end
+
+    # @param [FFI::Pointer] pointer to the address of the object
+    def self.finalize(pointer)
+      proc { CF.release(pointer) unless pointer.address.zero }
     end
 
     # Whether the instance is the CFNull singleton

--- a/lib/corefoundation/base.rb
+++ b/lib/corefoundation/base.rb
@@ -1,101 +1,35 @@
+# frozen_string_literal: true
 
 # The top level namespace for the corefoundation library. The raw FFI generated methods are attached here
-#
-#
 module CF
-  extend FFI::Library
-  ffi_lib '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
+  # The base class for all of the wrapper classes in CF module.
+  class Base
+    include CF::Memory
+    include CF::Register
+    # Allow setting the wrapper pointer. You should only do this rarely. If you have used release_on_gc then that
+    # finalizer will still be called on the original pointer value
+    attr_accessor :ptr
 
-  if FFI::Platform::ARCH == 'x86_64'
-    typedef :long_long, :cfindex
-    typedef :long_long, :cfcomparisonresult
-    typedef :ulong_long, :cfoptionflags
-    typedef :ulong_long, :cftypeid
-    typedef :ulong_long, :cfhashcode
-  else
-    typedef :long, :cfindex
-    typedef :long, :cfcomparisonresult
-    typedef :ulong, :cfoptionflags
-    typedef :ulong, :cftypeid
-    typedef :ulong, :cfhashcode
-  end
-
-
-  # @private
-  class Range < FFI::Struct
-    layout :location, :cfindex,
-           :length, :cfindex
-  end
-
-  typedef :pointer, :cftyperef
-
-  #general utility functions
-  attach_function :show, 'CFShow', [:cftyperef], :void
-  attach_function :release, 'CFRelease', [:cftyperef], :void
-  attach_function :retain, 'CFRetain', [:cftyperef], :cftyperef
-  attach_function 'CFEqual', [:cftyperef, :cftyperef], :char
-  attach_function 'CFHash', [:cftyperef], :cfhashcode
-  attach_function 'CFCopyDescription', [:cftyperef], :cftyperef
-  attach_function 'CFGetTypeID', [:cftyperef], :cftypeid
-
-  # The base class for all of the wrapper classes 
-  #
-  # @abstract
-  class Base  
-    @@type_map = {}
-
-    # @private
-    class Releaser
-      def initialize(ptr)
-        @address  = ptr.address
-      end
-
-      def call *ignored
-        if @address != 0
-          CF.release(@address)
-          @address = 0
-        end
-      end
-    end
-
-    class << self
-      # Raises an exception if the argument does not inherit from CF::Base
-      #
-      # @param cftyperef object to check
-      def check_cftype(cftyperef)
-        raise TypeError, "#{cftyperef.inspect} is not a cftype" unless cftyperef.is_a?(CF::Base)
-      end
-
-      # Wraps an FFI::Pointer with the appropriate subclass of CF::Base
-      # If the pointer is not a CFTypeRef behaviour is undefined
-      # @param [FFI::Pointer] cftyperef Object to wrap
-      # @return A wrapper object inheriting from CF::Base
-      def typecast(cftyperef)
-        klass = klass_from_cf_type cftyperef
-        klass.new(cftyperef)
-      end
-
-      private
-      def klass_from_cf_type cftyperef
-        klass = @@type_map[CF.CFGetTypeID(cftyperef)]
-        if !klass
-          raise TypeError, "No class registered for cf type #{cftyperef.inspect}"
-        end
-        klass
-      end
-
-      def register_type(type_name)
-        CF.attach_function "#{type_name}GetTypeID", [], :cftypeid
-        @@type_map[CF.send("#{type_name}GetTypeID")] = self
-      end
-
-    end
-
-    # 
+    # Raises an exception if the argument does not inherit from CF::Base
     #
-    # @param [FFI::Pointer] ptr The pointer to wrap
-    def initialize(ptr)
-      @ptr = FFI::Pointer.new(ptr)
+    # @param cftyperef object to check
+    def self.check_cftype(cftyperef)
+      raise TypeError, "#{cftyperef.inspect} is not a cftype" unless cftyperef.is_a?(CF::Base)
+    end
+
+    # Wraps an FFI::Pointer with the appropriate subclass of CF::Base
+    # If the pointer is not a CFTypeRef behaviour is undefined
+    #
+    # @param [FFI::Pointer] cftyperef Object to wrap
+    # @return A wrapper object inheriting from CF::Base
+    def self.typecast(cftyperef)
+      klass = klass_from_cf_type cftyperef
+      klass.new(cftyperef)
+    end
+
+    # @param [FFI::Pointer] pointer The pointer to wrap
+    def initialize(pointer)
+      @ptr = FFI::Pointer.new(pointer)
     end
 
     # Whether the instance is the CFNull singleton
@@ -103,49 +37,6 @@ module CF
     # @return [Boolean]
     def null?
       equals?(CF::NULL)
-    end
-
-    # Returns the wrapped pointer
-    # @return [FFI::Pointer]
-    def to_ptr
-      @ptr
-    end
-
-    # Sets the wrapper pointer. You should only do this rarely. If you have used release_on_gc then that
-    # finalizer will still be called on the original pointer value
-    #
-    def ptr= ptr
-      @ptr = ptr
-    end
-
-    # Calls CFRetain on the wrapped pointer
-    # @return Returns self
-    def retain
-      CF.retain(self)
-      self
-    end
-
-    # Calls CFRelease on the wrapped pointer
-    # @return Returns self
-    def release
-      CF.release(self)
-      self
-    end
-
-    # Installs a finalizer on the wrapper object that will cause it to call CFRelease on the pointer
-    # when the wrapper is garbage collected
-    # @return Returns self
-    def release_on_gc
-      ObjectSpace.define_finalizer(@ptr, Releaser.new(@ptr))
-      self
-    end
-
-    # Returns a ruby string containing the output of CFCopyDescription for the wrapped object
-    #
-    # @return [String]
-    def inspect
-      cf = CF::String.new(CF.CFCopyDescription(self))
-      cf.to_s.tap {cf.release}
     end
 
     # Uses CFHash to  return a hash code
@@ -156,8 +47,6 @@ module CF
     end
 
     # eql? (and ==) are implemented using CFEqual
-    #
-    #
     def eql?(other)
       if other.is_a?(CF::Base)
         CF.CFEqual(self, other) != 0
@@ -165,10 +54,10 @@ module CF
         false
       end
     end
-    
+
+    alias == :eql?
+
     # equals? is defined as returning true if the wrapped pointer is the same
-    #
-    #
     def equals?(other)
       if other.is_a?(CF::Base)
         @ptr.address == other.to_ptr.address
@@ -176,22 +65,9 @@ module CF
         false
       end
     end
-    
-    alias_method :==, :eql?
 
-    # Converts the CF object into a ruby object. Subclasses typically override this to return
-    # an appropriate object (for example CF::String returns a String)
-    #
     def to_ruby
-      self
-    end
-
-    # to_cf is a no-op on CF::Base and its descendants - it always returns self
-    #
-    #
-    def to_cf
-      self
+      raise "#{self.class} is missing an implemention for the to_ruby method."
     end
   end
-
 end

--- a/lib/corefoundation/data.rb
+++ b/lib/corefoundation/data.rb
@@ -23,11 +23,7 @@ module CF
     # @return [String]
     def to_s
       ptr = CF.CFDataGetBytePtr(self)
-      if CF::String::HAS_ENCODING
-        ptr.read_string(CF.CFDataGetLength(self)).force_encoding(Encoding::ASCII_8BIT)
-      else
-        ptr.read_string(CF.CFDataGetLength(self))
-      end
+      ptr.read_string(CF.CFDataGetLength(self)).force_encoding(Encoding::ASCII_8BIT)
     end
 
     # The size in bytes of the CFData

--- a/lib/corefoundation/data.rb
+++ b/lib/corefoundation/data.rb
@@ -15,7 +15,7 @@ module CF
     # @param [String] s the string to use
     # @return [CF::Data]
     def self.from_string(s)
-      new(CF.CFDataCreate(nil, s, s.bytesize)).release_on_gc
+      new(CF.CFDataCreate(nil, s, s.bytesize))
     end
 
     # Creates a ruby string from the wrapped data. The encoding will always be ASCII_8BIT

--- a/lib/corefoundation/date.rb
+++ b/lib/corefoundation/date.rb
@@ -17,7 +17,7 @@ module CF
     # @param [Time] time
     # @return [CF::Date] a CF::Date instance that will be released on garbage collection
     def self.from_time(time)
-      new(CF.CFDateCreate(nil, time.to_f - CF.kCFAbsoluteTimeIntervalSince1970)).release_on_gc
+      new(CF.CFDateCreate(nil, time.to_f - CF.kCFAbsoluteTimeIntervalSince1970))
     end
 
     # returns a ruby Time instance corresponding to the same point in time

--- a/lib/corefoundation/dictionary.rb
+++ b/lib/corefoundation/dictionary.rb
@@ -83,7 +83,6 @@ module CF
       self.class.check_cftype(key)
       self.class.check_cftype(value)
       CF.CFDictionarySetValue(self, key, value)
-      value
     end
 
     # Adds the key value pairs from the argument to self

--- a/lib/corefoundation/dictionary.rb
+++ b/lib/corefoundation/dictionary.rb
@@ -46,7 +46,7 @@ module CF
     #
     # @return [CF::Dictionary]
     def self.mutable
-      new(CF.CFDictionaryCreateMutable nil, 0, CF.kCFTypeDictionaryKeyCallBacks.to_ptr, CF.kCFTypeDictionaryValueCallBacks.to_ptr).release_on_gc
+      new(CF.CFDictionaryCreateMutable nil, 0, CF.kCFTypeDictionaryKeyCallBacks.to_ptr, CF.kCFTypeDictionaryValueCallBacks.to_ptr)
     end
 
     # Iterates over the array yielding the value to the block
@@ -55,7 +55,7 @@ module CF
 
     def each
       callback = lambda do |key, value, _|
-        yield [Base.typecast(key).retain.release_on_gc, Base.typecast(value).retain.release_on_gc]
+        yield [Base.typecast(key).retain, Base.typecast(value).retain]
       end
       CF.CFDictionaryApplyFunction(self, callback, nil)
       self
@@ -70,7 +70,7 @@ module CF
       key = CF::String.from_string(key) if key.is_a?(::String)
       self.class.check_cftype(key)
       raw = CF.CFDictionaryGetValue(self, key)
-      raw.null? ? nil : self.class.typecast(raw).retain.release_on_gc
+      raw.null? ? nil : self.class.typecast(raw).retain
     end
 
     # Sets the value associated with the key, or nil

--- a/lib/corefoundation/error.rb
+++ b/lib/corefoundation/error.rb
@@ -1,5 +1,0 @@
-module CF
-  class Error < StandardError
-    # TODO: add context to messages
-  end
-end

--- a/lib/corefoundation/exceptions.rb
+++ b/lib/corefoundation/exceptions.rb
@@ -1,0 +1,6 @@
+module CF
+  module Exceptions
+    # Raised when abstract method is not overridden
+    class MethodNotImplemented < StandardError; end
+  end
+end

--- a/lib/corefoundation/extensions.rb
+++ b/lib/corefoundation/extensions.rb
@@ -1,157 +1,165 @@
-# Rubyinteger
-class Integer
-  # Converts the Integer to a {CF::Number} using {CF::Number.from_i}
-  # @return [CF::Number]
-  def to_cf
-    CF::Number.from_i(self)
-  end
-end
+# frozen_string_literal: true
 
-# Ruby float class
-class Float
-  # Converts the Float to a {CF::Number} using {CF::Number.from_f}
-  # @return [CF::Number]
-  def to_cf
-    CF::Number.from_f(self)
-  end
-end
-
-# Ruby array class
-class Array
-  # Converts the Array to an immutable {CF::Array} by calling `to_cf` on each element it contains
-  # @return [CF::Number]
-  def to_cf
-    CF::Array.immutable(collect(&:to_cf))
-  end
-end
-
-# Ruby true class
-class TrueClass
-  # Returns a CF::Boolean object representing true
-  # @return [CF::Boolean]
-  def to_cf
-    CF::Boolean::TRUE
-  end
-end
-
-# Ruby false class
-class FalseClass
-  # Returns a CF::Boolean object representing false
-  # @return [CF::Boolean]
-  def to_cf
-    CF::Boolean::FALSE
-  end
-end
-
-# Ruby String class
-class String
-  # Returns a {CF::String} or {CF::Data} representing the string.
-  # If {#binary?} returns true a {CF::Data} is returned, if not a {CF::String} is returned
-  # 
-  # If you want a {CF::Data} with the contents of a non binary string, use {#to_cf_data}
-  #
-  # @return [CF::String, CF::Data]
-  def to_cf
-    self.binary? ? self.to_cf_data : self.to_cf_string
-  end
-
-  # @!method binary?
-  #
-  # used to determine whether {#to_cf} should return a {CF::String} or a {CF::Data}. On ruby 1.9 and above this simply 
-  # checks whether the encoding is ascii-8bit or not.
-  # 
-  # On ruby 1.8.7
-  #
-  # - A string is binary if you call {#binary!} with the default argument of true
-  # - A string is not binary if you call {#binary!} with the argument false
-  # 
-  # If you have never called {#binary!} then a string is binary if Iconv does not think it is valid utf-8
-  # @return whether the string is handled as binary data or not
-  #
-  if '<3'.respond_to? :encoding
-    def binary?
-      encoding == Encoding::ASCII_8BIT
+module CF
+  # REVIEW: Add patches as module and wrap them into CoreExtensions module.
+  #   This avoids opening ruby core classes and keeps the patches modularized.
+  #   Patches are then included in their respective core classes directly in a single place
+  #   making it easier to track and toggle the patches for the core classes.
+  module CoreExtensions
+    # Patches for ruby Integer
+    module Integer
+      # Converts the Integer to a {CF::Number} using {CF::Number.from_i}
+      # @return [CF::Number]
+      def to_cf
+        CF::Number.from_i(self)
+      end
     end
-  else
-    def binary?
-      unless defined? @cf_is_binary
-        begin
-          ::Iconv.conv('UTF-8', 'UTF-8', self)
-          return false if self.frozen?
-          @cf_is_binary = false
-        rescue Iconv::IllegalSequence
-          return true if self.frozen?
-          @cf_is_binary = true
+
+    # Patches for ruby Float
+    module Float
+      # Converts the Float to a {CF::Number} using {CF::Number.from_f}
+      # @return [CF::Number]
+      def to_cf
+        CF::Number.from_f(self)
+      end
+    end
+
+    # Patches for ruby Array
+    module Array
+      # Converts the Array to an immutable {CF::Array} by calling `to_cf` on each element it contains
+      # @return [CF::Number]
+      def to_cf
+        CF::Array.immutable(collect(&:to_cf))
+      end
+    end
+
+    # Patches for ruby TrueClass
+    module TrueClass
+      # Returns a CF::Boolean object representing true
+      # @return [CF::Boolean]
+      def to_cf
+        CF::Boolean::TRUE
+      end
+    end
+
+    # Patches for ruby FalseClass
+    module FalseClass
+      # Returns a CF::Boolean object representing false
+      # @return [CF::Boolean]
+      def to_cf
+        CF::Boolean::FALSE
+      end
+    end
+
+    # Patches for ruby String
+    module String
+      # Returns a {CF::String} or {CF::Data} representing the string.
+      # If {#binary?} returns true a {CF::Data} is returned, if not a {CF::String} is returned
+      #
+      # If you want a {CF::Data} with the contents of a non binary string, use {#to_cf_data}
+      #
+      # @return [CF::String, CF::Data]
+      def to_cf
+        binary? ? to_cf_data : to_cf_string
+      end
+
+      # @!method binary?
+      #
+      # used to determine whether {#to_cf} should return a {CF::String} or a {CF::Data}. On ruby 1.9 and above this simply
+      # checks whether the encoding is ascii-8bit or not.
+      #
+      # On ruby 1.8.7
+      #
+      # - A string is binary if you call {#binary!} with the default argument of true
+      # - A string is not binary if you call {#binary!} with the argument false
+      #
+      # If you have never called {#binary!} then a string is binary if Iconv does not think it is valid utf-8
+      # @return whether the string is handled as binary data or not
+      #
+      if '<3'.respond_to? :encoding
+        def binary?
+          encoding == Encoding::ASCII_8BIT
+        end
+      else
+        def binary?
+          unless defined? @cf_is_binary
+            begin
+              ::Iconv.conv('UTF-8', 'UTF-8', self)
+              return false if self.frozen?
+              @cf_is_binary = false
+            rescue Iconv::IllegalSequence
+              return true if self.frozen?
+              @cf_is_binary = true
+            end
+          end
+          @cf_is_binary
         end
       end
-      @cf_is_binary
-    end
-  end
 
-  if '<3'.respond_to? :encoding
-  # On ruby 1.8.7 sets or clears the flag used by {#binary?}. On ruby 1.9 the string's encoding is forced. 
-  # @see #binary?
-  # 
-  # @note There is no advantage to using this over the standard encoding methods unless you wish to retain 1.8.7 compatibility
-  #
-  # @param [optional, Boolean, Encoding] bin On ruby 1.8.7 only boolean values are admissible. On ruby 1.9 you can pass a specific encoding to force. 
-  #   If you pass `true` then `Encoding::ASCII_BIT` is used, if you pass `false` then `Encoding::UTF_8`
-  #
-    def binary!(bin=true)
-      if bin == true
-        self.force_encoding Encoding::ASCII_8BIT
+      if '<3'.respond_to? :encoding
+        # On ruby 1.8.7 sets or clears the flag used by {#binary?}. On ruby 1.9 the string's encoding is forced.
+        # @see #binary?
+        #
+        # NOTE: There is no advantage to using this over the standard encoding methods unless you wish to retain 1.8.7 compatibility
+        #
+        # @param [optional, Boolean, Encoding] bin On ruby 1.8.7 only boolean values are admissible. On ruby 1.9 you can pass a specific encoding to force.
+        #   If you pass `true` then `Encoding::ASCII_BIT` is used, if you pass `false` then `Encoding::UTF_8`
+        def binary!(bin: true)
+          if bin == true
+            force_encoding Encoding::ASCII_8BIT
+          else
+            # default to utf-8
+            force_encoding(bin == false ? 'UTF-8' : bin)
+          end
+          self
+        end
       else
-        # default to utf-8
-        self.force_encoding( (bin == false) ? "UTF-8" : bin)
+        # On ruby 1.8.7 sets or clears the flag used by {#binary?}. On ruby 1.9 the string's encoding is forced. 
+        # @see #binary?
+        #
+        # NOTE: There is no advantage to using this over the standard encoding methods unless you wish to retain 1.8.7 compatibility
+        #
+        # @param [optional, Boolean, Encoding] bin On ruby 1.8.7 only boolean values are admissible. On ruby 1.9 you can pass a specific encoding to force.
+        #   If you pass `true` then `Encoding::ASCII_BIT` is used, if you pass `false` then `Encoding::UTF_8`
+        #
+        def binary!(bin: true)
+          @cf_is_binary = bin
+          self
+        end
       end
-      self
-    end
-  else
-  # On ruby 1.8.7 sets or clears the flag used by {#binary?}. On ruby 1.9 the string's encoding is forced. 
-  # @see #binary?
-  # 
-  # @note There is no advantage to using this over the standard encoding methods unless you wish to retain 1.8.7 compatibility
-  #
-  # @param [optional, Boolean, Encoding] bin On ruby 1.8.7 only boolean values are admissible. On ruby 1.9 you can pass a specific encoding to force. 
-  #   If you pass `true` then `Encoding::ASCII_BIT` is used, if you pass `false` then `Encoding::UTF_8`
-  #
-    def binary!(bin=true)
-      @cf_is_binary = !! bin
-      self
-    end
-  end
-  
-  # Returns a {CF::String} representing the string
-  # @return [CF::String]
-  def to_cf_string
-    CF::String.from_string self
-  end
-  
-  # Returns a {CF::Data} representing the string
-  # @return [CF::Data]
-  def to_cf_data
-    CF::Data.from_string self
-  end
-  
-end
 
-# Ruby Time class
-class Time
-  # Returns a {CF::Date} representing the time.
-  # @return [CF::Date]
-  def to_cf
-    CF::Date.from_time(self)
-  end
-end
+      # Returns a {CF::String} representing the string
+      # @return [CF::String]
+      def to_cf_string
+        CF::String.from_string self
+      end
 
-# Ruby Hash class
-class Hash
-  # Converts the Hash to an mutable {CF::Dictionary} by calling `to_cf` on each key and value it contains
-  # @return [CF::Dictionary]
-  def to_cf
-    CF::Dictionary.mutable.tap do |r|
-      each do |k,v|
-        r[k.to_cf] = v.to_cf
+      # Returns a {CF::Data} representing the string
+      # @return [CF::Data]
+      def to_cf_data
+        CF::Data.from_string self
+      end
+    end
+
+    # Patches for ruby Time
+    module Time
+      # Returns a {CF::Date} representing the time.
+      # @return [CF::Date]
+      def to_cf
+        CF::Date.from_time(self)
+      end
+    end
+
+    # Patches for ruby Hash
+    module Hash
+      # Converts the Hash to an mutable {CF::Dictionary} by calling `to_cf` on each key and value it contains
+      # @return [CF::Dictionary]
+      def to_cf
+        CF::Dictionary.mutable.tap do |r|
+          each do |k, v|
+            r[k.to_cf] = v.to_cf
+          end
+        end
       end
     end
   end

--- a/lib/corefoundation/extensions.rb
+++ b/lib/corefoundation/extensions.rb
@@ -65,67 +65,25 @@ module CF
 
       # @!method binary?
       #
-      # used to determine whether {#to_cf} should return a {CF::String} or a {CF::Data}. On ruby 1.9 and above this simply
-      # checks whether the encoding is ascii-8bit or not.
+      # used to determine whether {#to_cf} should return a {CF::String} or a {CF::Data}.
+      # This simply checks whether the encoding is ascii-8bit or not.
       #
-      # On ruby 1.8.7
-      #
-      # - A string is binary if you call {#binary!} with the default argument of true
-      # - A string is not binary if you call {#binary!} with the argument false
-      #
-      # If you have never called {#binary!} then a string is binary if Iconv does not think it is valid utf-8
       # @return whether the string is handled as binary data or not
       #
-      if '<3'.respond_to? :encoding
-        def binary?
-          encoding == Encoding::ASCII_8BIT
-        end
-      else
-        def binary?
-          unless defined? @cf_is_binary
-            begin
-              ::Iconv.conv('UTF-8', 'UTF-8', self)
-              return false if self.frozen?
-              @cf_is_binary = false
-            rescue Iconv::IllegalSequence
-              return true if self.frozen?
-              @cf_is_binary = true
-            end
-          end
-          @cf_is_binary
-        end
+      def binary?
+        encoding == Encoding::ASCII_8BIT
       end
 
-      if '<3'.respond_to? :encoding
-        # On ruby 1.8.7 sets or clears the flag used by {#binary?}. On ruby 1.9 the string's encoding is forced.
-        # @see #binary?
-        #
-        # NOTE: There is no advantage to using this over the standard encoding methods unless you wish to retain 1.8.7 compatibility
-        #
-        # @param [optional, Boolean, Encoding] bin On ruby 1.8.7 only boolean values are admissible. On ruby 1.9 you can pass a specific encoding to force.
-        #   If you pass `true` then `Encoding::ASCII_BIT` is used, if you pass `false` then `Encoding::UTF_8`
-        def binary!(bin: true)
-          if bin == true
-            force_encoding Encoding::ASCII_8BIT
-          else
-            # default to utf-8
-            force_encoding(bin == false ? 'UTF-8' : bin)
-          end
-          self
+      # @param [optional, Boolean, Encoding] bin
+      # If you pass `true` then `Encoding::ASCII_BIT` is used, if you pass `false` then `Encoding::UTF_8`
+      def binary!(bin = true)
+        if bin == true
+          force_encoding Encoding::ASCII_8BIT
+        else
+          # default to utf-8
+          force_encoding(bin == false ? "UTF-8" : bin)
         end
-      else
-        # On ruby 1.8.7 sets or clears the flag used by {#binary?}. On ruby 1.9 the string's encoding is forced. 
-        # @see #binary?
-        #
-        # NOTE: There is no advantage to using this over the standard encoding methods unless you wish to retain 1.8.7 compatibility
-        #
-        # @param [optional, Boolean, Encoding] bin On ruby 1.8.7 only boolean values are admissible. On ruby 1.9 you can pass a specific encoding to force.
-        #   If you pass `true` then `Encoding::ASCII_BIT` is used, if you pass `false` then `Encoding::UTF_8`
-        #
-        def binary!(bin: true)
-          @cf_is_binary = bin
-          self
-        end
+        self
       end
 
       # Returns a {CF::String} representing the string

--- a/lib/corefoundation/extensions.rb
+++ b/lib/corefoundation/extensions.rb
@@ -113,6 +113,7 @@ module CF
       # Converts the Hash to an mutable {CF::Dictionary} by calling `to_cf` on each key and value it contains
       # @return [CF::Dictionary]
       def to_cf
+        transform_keys! &:to_s # Convert all keys to strings
         CF::Dictionary.mutable.tap do |r|
           each do |k, v|
             r[k.to_cf] = v.to_cf

--- a/lib/corefoundation/memory.rb
+++ b/lib/corefoundation/memory.rb
@@ -2,25 +2,6 @@
 
 # The top level namespace for the corefoundation library. The raw FFI generated methods are attached here
 module CF
-  extend FFI::Library
-  ffi_lib '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
-
-  if FFI::Platform::ARCH == 'x86_64'
-    typedef :long_long, :cfindex
-    typedef :long_long, :cfcomparisonresult
-    typedef :ulong_long, :cfoptionflags
-    typedef :ulong_long, :cftypeid
-    typedef :ulong_long, :cfhashcode
-  else
-    typedef :long, :cfindex
-    typedef :long, :cfcomparisonresult
-    typedef :ulong, :cfoptionflags
-    typedef :ulong, :cftypeid
-    typedef :ulong, :cfhashcode
-  end
-
-  typedef :pointer, :cftyperef
-
   attach_function :show, 'CFShow', [:cftyperef], :void
   attach_function :release, 'CFRelease', [:cftyperef], :void
   attach_function :retain, 'CFRetain', [:cftyperef], :cftyperef
@@ -28,12 +9,6 @@ module CF
   attach_function 'CFHash', [:cftyperef], :cfhashcode
   attach_function 'CFCopyDescription', [:cftyperef], :cftyperef
   attach_function 'CFGetTypeID', [:cftyperef], :cftypeid
-
-  # @private
-  class Range < FFI::Struct
-    layout :location, :cfindex,
-           :length, :cfindex
-  end
 
   # Provides a more declarative way to define all required abstract methods.
   # This gets included in the CF::Base class whose subclasses then need to define those methods.

--- a/lib/corefoundation/memory.rb
+++ b/lib/corefoundation/memory.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# The top level namespace for the corefoundation library. The raw FFI generated methods are attached here
+module CF
+  extend FFI::Library
+  ffi_lib '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
+
+  if FFI::Platform::ARCH == 'x86_64'
+    typedef :long_long, :cfindex
+    typedef :long_long, :cfcomparisonresult
+    typedef :ulong_long, :cfoptionflags
+    typedef :ulong_long, :cftypeid
+    typedef :ulong_long, :cfhashcode
+  else
+    typedef :long, :cfindex
+    typedef :long, :cfcomparisonresult
+    typedef :ulong, :cfoptionflags
+    typedef :ulong, :cftypeid
+    typedef :ulong, :cfhashcode
+  end
+
+  typedef :pointer, :cftyperef
+
+  attach_function :show, 'CFShow', [:cftyperef], :void
+  attach_function :release, 'CFRelease', [:cftyperef], :void
+  attach_function :retain, 'CFRetain', [:cftyperef], :cftyperef
+  attach_function 'CFEqual', [:cftyperef, :cftyperef], :char
+  attach_function 'CFHash', [:cftyperef], :cfhashcode
+  attach_function 'CFCopyDescription', [:cftyperef], :cftyperef
+  attach_function 'CFGetTypeID', [:cftyperef], :cftypeid
+
+  # @private
+  class Range < FFI::Struct
+    layout :location, :cfindex,
+           :length, :cfindex
+  end
+
+  # Provides a more declarative way to define all required abstract methods.
+  # This gets included in the CF::Base class whose subclasses then need to define those methods.
+  module Memory
+
+    # Private releaser class providers the block to execute after garbage collection.
+    # REVIEW: If we remove setter for `@ptr`, then we can probably remove the need for this class
+    #   and directly define a proc in the release_on_gc method.
+    class Releaser
+      def initialize(ptr)
+        @address = ptr.address
+      end
+
+      def call(*)
+        return unless @address != 0
+
+        CF.release(@address)
+        @address = 0
+      end
+    end
+
+    # Returns a ruby string containing the output of CFCopyDescription for the wrapped object
+    #
+    # @return [String]
+    def inspect
+      cf = CF::String.new(CF.CFCopyDescription(self))
+      cf.to_s.tap { cf.release }
+    end
+
+    # Calls CFRelease on the wrapped pointer
+    #
+    # @return Returns self
+    def release
+      CF.release(self)
+      self
+    end
+
+    # Installs a finalizer on the wrapper object that will cause it to call CFRelease on the pointer
+    # when the wrapper is garbage collected
+    #
+    # @return Returns self
+    def release_on_gc
+      ObjectSpace.define_finalizer(ptr, Releaser.new(ptr))
+      self
+    end
+
+    # Calls CFRetain on the wrapped pointer
+    #
+    # @return Returns self
+    def retain
+      CF.retain(self)
+      self
+    end
+
+    # This is a no-op on CF::Base and its subclasses. Always returns self.
+    #
+    # @return Returns self
+    def to_cf
+      self
+    end
+
+    # Returns the wrapped pointer
+    #
+    # @return [FFI::Pointer]
+    def to_ptr
+      ptr
+    end
+
+    private_constant :Releaser
+  end
+end

--- a/lib/corefoundation/number.rb
+++ b/lib/corefoundation/number.rb
@@ -39,7 +39,7 @@ module CF
     def self.from_f(float)
       p = FFI::MemoryPointer.new(:double)
       p.write_double(float.to_f)
-      new(CF.CFNumberCreate(nil, :kCFNumberDoubleType, p)).release_on_gc
+      new(CF.CFNumberCreate(nil, :kCFNumberDoubleType, p))
     end
 
     # Constructs a CF::Number from an integer
@@ -48,7 +48,7 @@ module CF
     def self.from_i(int)
       p = FFI::MemoryPointer.new(:int64)
       p.put_int64(0,int.to_i)
-      new(CF.CFNumberCreate(nil, :kCFNumberSInt64Type, p)).release_on_gc
+      new(CF.CFNumberCreate(nil, :kCFNumberSInt64Type, p))
     end
 
     # Compares the receiver with the argument

--- a/lib/corefoundation/range.rb
+++ b/lib/corefoundation/range.rb
@@ -1,0 +1,10 @@
+module CF
+  #
+  # Maps to the corefoundation structure CFRange.
+  # See usage in CF::Array and CF::String.
+  #
+  class Range < FFI::Struct
+    layout :location, :cfindex,
+           :length, :cfindex
+  end
+end

--- a/lib/corefoundation/register.rb
+++ b/lib/corefoundation/register.rb
@@ -1,0 +1,32 @@
+require "singleton"
+
+module CF
+  module Register
+    class RegisteredTypes
+      include Singleton
+      @type_map = {}
+    end
+
+    def self.included base
+      base.extend self
+    end
+
+    def register_type(type_name)
+      CF.attach_function "#{type_name}GetTypeID", [], :cftypeid
+      types = RegisteredTypes.instance_variable_get(:@type_map)
+      types[CF.send("#{type_name}GetTypeID")] = self
+      RegisteredTypes.instance_variable_set(:@type_map, types)
+    end
+
+    private
+
+    def klass_from_cf_type(cftyperef)
+      klass = RegisteredTypes.instance_variable_get(:@type_map)[CF.CFGetTypeID(cftyperef)]
+      raise TypeError, "No class registered for cf type #{cftyperef.inspect}" unless klass
+
+      klass
+    end
+
+    private_constant :RegisteredTypes
+  end
+end

--- a/lib/corefoundation/string.rb
+++ b/lib/corefoundation/string.rb
@@ -20,24 +20,13 @@ module CF
     # The cfstring encoding for UTF8
     UTF8 = 0x08000100 #From cfstring.h
 
-    # workaround for ruby 1.8.7 compat
-    HAS_ENCODING = "foo".respond_to? "encode"
-
     # Creates a string from a ruby string
     # The string must be convertable to UTF-8
     #
     # @param [String] s 
     # @return [CF::String]
-    def self.from_string(s, src_encoding='UTF-8')
-      if HAS_ENCODING
-        s_utf = s.encode('UTF-8')
-      else
-        begin
-          s_utf = Iconv.conv('UTF-8', src_encoding, s.to_s)
-        rescue Iconv::IllegalSequence => e
-          return nil
-        end
-      end
+    def self.from_string(s)
+      s_utf = s.encode("UTF-8")
       raw = CF.CFStringCreateWithBytes(nil, s_utf, s_utf.bytesize, UTF8, 0)
       raw.null? ? nil : new(raw)
     end
@@ -65,27 +54,15 @@ module CF
       range[:location] = 0
       range[:length] = length
       buffer = FFI::MemoryPointer.new(:char, max_size)
-
       cfindex = CF.find_type(:cfindex)
       bytes_used_buffer = FFI::MemoryPointer.new(cfindex)
 
       CF.CFStringGetBytes(self, range, UTF8, 0, 0, buffer, max_size, bytes_used_buffer)
+      len = bytes_used_buffer.send(cfindex == CF.find_type(:long_long) ? :read_long_long : :read_long)
 
-      bytes_used = if cfindex == CF.find_type(:long_long)
-        bytes_used_buffer.read_long_long
-      else
-        bytes_used_buffer.read_long
-      end
-
-      if HAS_ENCODING
-        buffer.read_string(bytes_used).force_encoding(Encoding::UTF_8)
-      else
-        buffer.read_string(bytes_used)
-      end
+      buffer.read_string(len).force_encoding(Encoding::UTF_8)
     end
-
-    alias_method :to_ruby, :to_s
-
+    alias to_ruby to_s
   end
 
 end

--- a/lib/corefoundation/string.rb
+++ b/lib/corefoundation/string.rb
@@ -39,7 +39,7 @@ module CF
         end
       end
       raw = CF.CFStringCreateWithBytes(nil, s_utf, s_utf.bytesize, UTF8, 0)
-      raw.null? ? nil : new(raw).release_on_gc
+      raw.null? ? nil : new(raw)
     end
 
     # Returns the length, in unicode characters of the string

--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe CF::Array do
   describe 'mutable' do
-    subject { CF::Array.mutable}
-    
-    it { should be_a(CF::Array)}
-    it { should be_mutable}
+    subject { CF::Array.mutable }
+
+    it { is_expected.to be_a(CF::Array) }
+    it { is_expected.to be_mutable }
 
     describe '[]=' do
       it 'should raise when trying to store a non cf value' do
@@ -27,7 +27,7 @@ describe CF::Array do
     end
 
     it 'should return an immutable cfarray' do
-      CF::Array.immutable([CF::Boolean::TRUE]).should be_a(CF::Array)
+      expect(CF::Array.immutable([CF::Boolean::TRUE])).to be_a(CF::Array)
     end
     
     context 'with an immutable array' do
@@ -52,21 +52,21 @@ describe CF::Array do
 
     describe '[]' do
       it 'should return the typecast value at the index' do
-        subject[1].should be_a(CF::String)
-        subject[1].should == CF::String.from_string('123')
+        expect(subject[1]).to be_a(CF::String)
+        expect(subject[1]).to eq(CF::String.from_string('123'))
       end
     end
 
 
     describe 'length' do
       it 'should return the count of items in the dictionary' do
-        subject.length.should == 2
+        expect(subject.length).to eq(2)
       end
     end
 
     describe 'to_ruby' do
       it 'should return the result of calling to ruby on its contents' do
-        subject.to_ruby.should == [true, '123']
+        expect(subject.to_ruby).to eq([true, '123'])
       end
     end
 
@@ -76,8 +76,8 @@ describe CF::Array do
         subject.each do |v|
           values << v
         end
-        values[0].should == CF::Boolean::TRUE
-        values[1].should == CF::String.from_string('123')
+        expect(values[0]).to eq(CF::Boolean::TRUE)
+        expect(values[1]).to eq(CF::String.from_string('123'))
       end
     end
 
@@ -86,7 +86,7 @@ describe CF::Array do
       subject.each_with_index do |value, index|
         values[index] = value
       end
-      values.should == {0 => CF::Boolean::TRUE, 1 => CF::String.from_string('123')}
+      expect(values).to eq({ 0 => CF::Boolean::TRUE, 1 => CF::String.from_string('123') })
     end
   end
 end

--- a/spec/boolean_spec.rb
+++ b/spec/boolean_spec.rb
@@ -6,16 +6,16 @@ describe CF do
   describe CF::Boolean do
     describe 'value' do
       it 'should return true for CF::Boolean::TRUE' do
-        CF::Boolean::TRUE.value.should == true
+        expect(CF::Boolean::TRUE.value).to eq(true)
       end
       it 'should return false for CF::Boolean::FALSE' do
-        CF::Boolean::FALSE.value.should == false
+        expect(CF::Boolean::FALSE.value).to eq(false)
       end
     end
 
     describe 'to_ruby' do
       it 'should behave like value' do
-        CF::Boolean::FALSE.to_ruby.should == false
+        expect(CF::Boolean::FALSE.to_ruby).to eq(false)
       end
     end
 

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -6,10 +6,8 @@ describe CF::Data do
   describe '#to_s' do
     it 'should return a binary ruby string' do
       ruby_string = subject.to_s
-      ruby_string.should == 'A CF string'
-      if CF::String::HAS_ENCODING
-        ruby_string.encoding.should == Encoding::ASCII_8BIT
-      end
+      expect(ruby_string).to eq("A CF string")
+      expect(ruby_string.encoding).to eq(Encoding::ASCII_8BIT)
     end
   end
 

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -13,15 +13,15 @@ describe CF::Data do
 
   describe '#size' do
     it 'should return the size in bytes of the cfdata' do
-      subject.size.should == 11
+      expect(subject.size).to eq(11)
     end
   end
 
   describe 'to_ruby' do
     it 'should behave like to_s' do
-      subject.to_ruby.should == 'A CF string'
+      expect(subject.to_ruby).to eq('A CF string')
       if 'A CF string'.respond_to? "encoding"
-        subject.to_ruby.encoding.should == Encoding::ASCII_8BIT
+        expect(subject.to_ruby.encoding).to eq(Encoding::ASCII_8BIT)
       end
     end
   end

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -3,22 +3,22 @@ require 'spec_helper'
 describe CF::Date do
   describe('from_time') do
     it 'should create a cf date from a time' do
-      CF::Date.from_time(Time.now).should be_a(CF::Date)
+      expect(CF::Date.from_time(Time.now)).to be_a(CF::Date)
     end
   end
 
   describe('to_time') do
     it 'should return a time' do
       t = CF::Date.from_time(Time.now).to_time
-      t.should be_a(Time)
-      t.should be_within(0.01).of(Time.now)
+      expect(t).to be_a(Time)
+      expect(t).to be_within(0.01).of(Time.now)
     end
   end
 
   describe 'to_ruby' do
     it 'should behave like to_time' do
       t = CF::Date.from_time(Time.now).to_ruby
-      t.should be_a(Time)
+      expect(t).to be_a(Time)
     end
   end
 end

--- a/spec/dictionary_spec.rb
+++ b/spec/dictionary_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe CF::Dictionary do
   describe 'mutable' do
     it 'should return  a cf dictionary' do
-      CF::Dictionary.mutable.should be_a(CF::Dictionary)
+      expect(CF::Dictionary.mutable).to be_a(CF::Dictionary)
     end
   end
 
@@ -12,7 +12,7 @@ describe CF::Dictionary do
     subject {CF::Dictionary.mutable}
 
     it 'should return nil when the key does not exist' do
-      subject['doesnotexist'].should be_nil
+      expect(subject['doesnotexist']).to be_nil
     end
 
     it 'should raise when trying to store a non cf value' do
@@ -29,12 +29,12 @@ describe CF::Dictionary do
 
     it 'should instantiate the correct type on retrieval' do
       subject[CF::String.from_string('key')] = CF::String.from_string('value')
-      subject[CF::String.from_string('key')].should be_a(CF::String)
+      expect(subject[CF::String.from_string('key')]).to be_a(CF::String)
     end
 
     it 'should coerce string keys' do
       subject['key'] = CF::String.from_string('value')
-      subject['key'].to_s.should == 'value'
+      expect(subject['key'].to_s).to eq('value')
     end
   end
 
@@ -43,7 +43,7 @@ describe CF::Dictionary do
     it 'should merge the argument into the receiver' do
       argument = {'1' => false, 'foo' => 'bar'}.to_cf
       subject.merge! argument
-      subject.to_ruby.should == {'1' => false, '2' => false, 'foo' => 'bar'}
+      expect(subject.to_ruby).to eq({ '1' => false, '2' => false, 'foo' => 'bar' })
     end
   end
 
@@ -53,7 +53,7 @@ describe CF::Dictionary do
       dict['one'] = CF::Boolean::TRUE
       dict['two'] = CF::Boolean::TRUE
 
-      dict.length.should == 2
+      expect(dict.length).to eq(2)
     end
   end
 
@@ -65,8 +65,8 @@ describe CF::Dictionary do
       subject.each do |k,v|
         hash[k] = v
       end
-      hash.should == {CF::String.from_string('1') => CF::Boolean::TRUE, 
-                      CF::String.from_string('2') => CF::Boolean::FALSE}
+      expect(hash).to eq({ CF::String.from_string('1') => CF::Boolean::TRUE,
+                       CF::String.from_string('2') => CF::Boolean::FALSE })
     end
   end
 
@@ -74,7 +74,7 @@ describe CF::Dictionary do
     subject { CF::Dictionary.mutable.tap {|dict| dict['1'] = CF::Boolean::TRUE; dict['2'] = CF::Array.immutable([CF::Boolean::FALSE])}}
 
     it 'should return a ruby hash where keys and values have been converted to ruby types' do
-      subject.to_ruby.should == {'1' => true, '2' => [false]}
+      expect(subject.to_ruby).to eq({ '1' => true, '2' => [false] })
     end
   end
 

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -58,14 +58,8 @@ describe 'extensions' do
         '123'.should_not be_binary
       end
 
-      if CF::String::HAS_ENCODING
-        it 'should return false on valid utf data' do
-          "\xc3\xc9".should_not be_binary
-        end
-      else
-        it 'should return false on valid utf data' do
-          uber.pack("C*").should_not be_binary
-        end
+      it "should return false on valid utf data" do
+        expect("\xc3\xc9").not_to be_binary
       end
 
       it 'should return false on string forced to non binary' do
@@ -76,14 +70,8 @@ describe 'extensions' do
         '123'.binary!.should be_binary
       end
 
-      if CF::String::HAS_ENCODING
-        it 'should return true for ascii 8bit strings' do
-          '123'.encode(Encoding::ASCII_8BIT).should be_binary
-        end
-      else
-        it 'should return true for data that cannot be converted to utf8' do
-          "\xff\xff\xff".should be_binary
-        end
+      it "should return true for ascii 8bit strings" do
+        expect("123".encode(Encoding::ASCII_8BIT)).to be_binary
       end
     end
 

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 describe 'extensions' do
   context 'with an integer' do
     it 'should return a cfnumber' do
-      1.to_cf.should be_a(CF::Number)
+      expect(1.to_cf).to be_a(CF::Number)
     end
   end
 
   context 'with a float' do
     it 'should return a cfnumber' do
-      (1.0).to_cf.should be_a(CF::Number)
+      expect(1.0.to_cf).to be_a(CF::Number)
     end
   end
 
@@ -22,32 +22,32 @@ describe 'extensions' do
       unless defined? RUBY_ENGINE and RUBY_ENGINE == 'jruby'
         context 'with data incorrectly marked as non binary' do
           it 'returns nil' do
-            [0xff, 0xff, 0xff].pack("C*").binary!(false).to_cf.should be_nil
+            expect([0xff, 0xff, 0xff].pack('C*').binary!(false).to_cf).to be_nil
           end
         end
       end
 
       context 'with a non binary string' do
         it 'should return a cf string' do
-          '123'.to_cf.should be_a(CF::String)
+          expect('123'.to_cf).to be_a(CF::String)
         end
       end
 
       context 'with a string marked as binary' do
         it 'should return a cf data' do
-          '123'.binary!.to_cf.should be_a(CF::Data)
+          expect('123'.binary!.to_cf).to be_a(CF::Data)
         end
       end
 
       context 'with a binary string' do    
         it 'should return a cf data' do
-          [0xff, 0xff, 0xff].pack("C*").to_cf.should be_a(CF::Data)
+          expect([0xff, 0xff, 0xff].pack('C*').to_cf).to be_a(CF::Data)
         end
       end
 
       context 'with a utf-8 string' do
         it 'should return a cfstring' do
-          uber.pack("C*").should_not be_a(CF::String)
+          expect(uber.pack('C*')).not_to be_a(CF::String)
         end
       end
     end
@@ -55,7 +55,7 @@ describe 'extensions' do
     describe 'binary?' do
 
       it 'should return false on a plain ascii string' do
-        '123'.should_not be_binary
+        expect('123').not_to be_binary
       end
 
       it "should return false on valid utf data" do
@@ -63,11 +63,11 @@ describe 'extensions' do
       end
 
       it 'should return false on string forced to non binary' do
-        "\xc3\xc9".binary!(false).should_not be_binary
+        expect("\xc3\xc9".binary!(false)).not_to be_binary
       end
 
       it 'should return true if binary! has been called' do
-        '123'.binary!.should be_binary
+        expect('123'.binary!).to be_binary
       end
 
       it "should return true for ascii 8bit strings" do
@@ -79,37 +79,37 @@ describe 'extensions' do
 
   context 'with true' do
     it 'should return CF::Boolean::TRUE' do
-      true.to_cf.should == CF::Boolean::TRUE
+      expect(true.to_cf).to eq(CF::Boolean::TRUE)
     end
   end
 
   context 'with false' do
     it 'should return CF::Boolean::FALSE' do
-      false.to_cf.should == CF::Boolean::FALSE
+      expect(false.to_cf).to eq(CF::Boolean::FALSE)
     end
   end
 
   context 'with a time' do
     it 'should return a CFDate' do
-      Time.now.to_cf.should be_a(CF::Date)
+      expect(Time.now.to_cf).to be_a(CF::Date)
     end
   end
 
   context 'with an array' do
     it 'should return a cfarray containing cf objects' do
       cf_array = [true, 1, 'hello'].to_cf
-      cf_array.should be_a(CF::Array)
-      cf_array[0].should == CF::Boolean::TRUE
-      cf_array[1].should be_a(CF::Number)
-      cf_array[2].should == CF::String.from_string('hello')
+      expect(cf_array).to be_a(CF::Array)
+      expect(cf_array[0]).to eq(CF::Boolean::TRUE)
+      expect(cf_array[1]).to be_a(CF::Number)
+      expect(cf_array[2]).to eq(CF::String.from_string('hello'))
     end
   end
 
   context 'with a dictionary' do
     it 'should return a cfdictionary containing cf objects' do
-      cf_hash = {'key_1' => true, 'key_2' => false}.to_cf
-      cf_hash['key_1'].should == CF::Boolean::TRUE
-      cf_hash['key_2'].should == CF::Boolean::FALSE
+      cf_hash = { 'key_1' => true, 'key_2' => false }.to_cf
+      expect(cf_hash['key_1']).to eq(CF::Boolean::TRUE)
+      expect(cf_hash['key_2']).to eq(CF::Boolean::FALSE)
     end
   end
 end

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -113,3 +113,12 @@ describe 'extensions' do
     end
   end
 end
+
+describe Hash do
+  context "to_cf" do
+    it 'should return a CF::Dictionary' do
+      input = { "key1": "value", :key2 => "value2" }
+      expect(input.to_cf).to be_a CF::Dictionary
+    end
+  end
+end

--- a/spec/null_spec.rb
+++ b/spec/null_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe CF::Null do
   it 'should be null' do
-    CF::NULL.should be_null
+    expect(CF::NULL).to be_null
   end
 end

--- a/spec/number_spec.rb
+++ b/spec/number_spec.rb
@@ -6,47 +6,47 @@ describe CF::Number do
     context 'with a number created from a float' do
       subject {CF::Number.from_f('3.1415')} 
       it 'should return a float' do
-        subject.to_ruby.should be_within(0.0000001).of(3.14150)
+        expect(subject.to_ruby).to be_within(0.0000001).of(3.14150)
       end
     end
     context 'with a number created from a int' do
       subject {CF::Number.from_i('31415')} 
       it 'should return a int' do
-        subject.to_ruby.should == 31415
-        subject.to_ruby.should be_a(Integer)
+        expect(subject.to_ruby).to eq(31_415)
+        expect(subject.to_ruby).to be_a(Integer)
       end
     end
   end
 
   it 'should be comparable' do
-    (CF::Number.from_f('3.1415') <= CF::Number.from_i(4)).should be_true
+    expect(CF::Number.from_f('3.1415') <= CF::Number.from_i(4)).to be true
   end
 
   describe('from_f') do 
     it 'should create a cf number from a float' do
-      CF::Number.from_f('3.1415').should be_a(CF::Number)
+      expect(CF::Number.from_f('3.1415')).to be_a(CF::Number)
     end
   end
 
   describe('from_i') do 
     it 'should create a cf number from a 32 bit sized int' do
-      CF::Number.from_i(2**30).should be_a(CF::Number)
+      expect(CF::Number.from_i(2**30)).to be_a(CF::Number)
     end
 
     it 'should create a cf number from a 64 bit sized int' do
-      CF::Number.from_i(2**60).should be_a(CF::Number)
+      expect(CF::Number.from_i(2**60)).to be_a(CF::Number)
     end
   end
 
   describe('to_i') do
     it 'should return a ruby integer representing the cfnumber' do
-      CF::Number.from_i(2**60).to_i.should == 2**60
+      expect(CF::Number.from_i(2**60).to_i).to eq(2**60)
     end
   end
 
   describe('to_f') do
     it 'should return a ruby float representing the cfnumber' do
-      CF::Number.from_f(3.1415).to_f.should be_within(0.0000001).of(3.14150)
+      expect(CF::Number.from_f(3.1415).to_f).to be_within(0.0000001).of(3.14150)
     end
   end
 end

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -9,36 +9,27 @@ describe CF::String do
 
     # The intent is to force feed CF::String with an invalid utf-8 string
     # but jruby doesn't seem to allow this to be constructed
-    unless defined? RUBY_ENGINE and RUBY_ENGINE == 'jruby'
-      context 'with invalid data' do
-        it 'returns nil' do
-          if CF::String::HAS_ENCODING
-            CF::String.from_string("\xff\xff\xff".force_encoding('UTF-8')).should be_nil
-          else
-            CF::String.from_string("\xff\xff\xff").should be_nil
-          end
+    unless defined? RUBY_ENGINE && (RUBY_ENGINE == "jruby")
+      context "with invalid data" do
+        it "returns nil" do
+          expect(CF::String.from_string("\xff\xff\xff".force_encoding("UTF-8"))).to be_nil
         end
       end
     end
   end
 
-  describe '#to_s' do
-    it 'should return a utf ruby string' do
-      ruby_string = CF::String.from_string('A CF string').to_s
-      ruby_string.should == 'A CF string'
-      if CF::String::HAS_ENCODING
-        ruby_string.encoding.should == Encoding::UTF_8
-      else
-      end
+  describe "#to_s" do
+    it "should return a utf ruby string" do
+      ruby_string = CF::String.from_string("A CF string").to_s
+      expect(ruby_string).to eq("A CF string")
+      expect(ruby_string.encoding).to eq(Encoding::UTF_8)
     end
   end
 
-  describe 'to_ruby' do
-    it 'should behave like to_s' do
-      CF::String.from_string('A CF string').to_ruby.should == 'A CF string'
-      if CF::String::HAS_ENCODING
-        CF::String.from_string('A CF string').to_ruby.encoding.should == Encoding::UTF_8
-      end
+  describe "to_ruby" do
+    it "should behave like to_s" do
+      expect(CF::String.from_string("A CF string").to_ruby).to eq("A CF string")
+      expect(CF::String.from_string("A CF string").to_ruby.encoding).to eq(Encoding::UTF_8)
     end
   end
 

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -4,7 +4,7 @@ describe CF::String do
 
   describe 'from_string' do
     it 'should return a CF::String' do
-      CF::String.from_string('A CF string').should be_a(CF::String)
+      expect(CF::String.from_string('A CF string')).to be_a(CF::String)
     end
 
     # The intent is to force feed CF::String with an invalid utf-8 string
@@ -34,6 +34,6 @@ describe CF::String do
   end
 
   it 'should be comparable' do
-    CF::String.from_string('aaa').should  <= CF::String.from_string('zzz')
+    expect(CF::String.from_string('aaa')).to be <= CF::String.from_string('zzz')
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Base class was doing too much at one place. Separating out the concerns to appropriate modules would help maintaining the different parts. Also includes minor improvements (auto releasing memory, prevent accidental overwrite of state)

1. Cleaned up base class.
2. Move type registration and tracking to `Register` module.
3. Move memory operations to a separate `Memory` module.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
