### PR TITLE
Fix use of zero? for ruby 3.1

### DIFF
--- a/lib/corefoundation/base.rb
+++ b/lib/corefoundation/base.rb
@@ -37,7 +37,7 @@ module CF
 
     # @param [FFI::Pointer] pointer to the address of the object
     def self.finalize(pointer)
-      proc { CF.release(pointer) unless pointer.address.zero }
+      proc { CF.release(pointer) unless pointer.address.zero? }
     end
 
     # Whether the instance is the CFNull singleton

--- a/lib/corefoundation/base.rb
+++ b/lib/corefoundation/base.rb
@@ -37,7 +37,7 @@ module CF
 
     # @param [FFI::Pointer] pointer to the address of the object
     def self.finalize(pointer)
-      proc { CF.release(pointer) unless pointer.address.zero? }
+      proc { CF.release(pointer.address) unless pointer.address.zero? }
     end
 
     # Whether the instance is the CFNull singleton


### PR DESCRIPTION
This fixes errors like this on ruby 3.1:

```
/Users/lamont/.asdf/installs/ruby/3.1.0/bin/bundle: warning: Exception in finalizer #<Proc:0x0000000107445e00 /Users/lamont/stow/root/oc/corefoundation/lib/corefoundation/base.rb:40>
/Users/lamont/stow/root/oc/corefoundation/lib/corefoundation/base.rb:40:in `block in finalize': undefined method `zero' for 105553150512992:Integer (NoMethodError)

      proc { CF.release(pointer) unless pointer.address.zero }
                                                       ^^^^^
Did you mean?  zero?
```
