### PR TITLE
Fix NoMethodError for zero() => zero?()

### DIFF
--- a/lib/corefoundation/base.rb
+++ b/lib/corefoundation/base.rb
@@ -37,7 +37,7 @@ module CF
 
     # @param [FFI::Pointer] pointer to the address of the object
     def self.finalize(pointer)
-      proc { CF.release(pointer) unless pointer.address.zero }
+      proc { CF.release(pointer) unless pointer.address.zero? }
     end
 
     # Whether the instance is the CFNull singleton


### PR DESCRIPTION
Obvious fix.

Error was:

    $ bundle exec chef-solo --version
    Chef Infra Client: 17.9.18
    ~/.rvm/rubies/ruby-3.1.0/bin/ruby_executable_hooks: warning: Exception in finalizer #<Proc:0x0000000109989720 ~/src/pub/soloist/sprout-wrap/vendor/bundle/ruby/3.1.0/gems/corefoundation-0.3.4/lib/corefoundation/base.rb:40>
    ~/src/pub/soloist/sprout-wrap/vendor/bundle/ruby/3.1.0/gems/corefoundation-0.3.4/lib/corefoundation/base.rb:40:in `block in finalize': undefined method `zero' for 9132836560:Integer (NoMethodError)

          proc { CF.release(pointer) unless pointer.address.zero }
                                                           ^^^^^
    Did you mean?  zero?
    ~/.rvm/rubies/ruby-3.1.0/bin/ruby_executable_hooks: warning: Exception in finalizer #<Proc:0x0000000109989928 ~/src/pub/soloist/sprout-wrap/vendor/bundle/ruby/3.1.0/gems/corefoundation-0.3.4/lib/corefoundation/base.rb:40>
    ~/src/pub/soloist/sprout-wrap/vendor/bundle/ruby/3.1.0/gems/corefoundation-0.3.4/lib/corefoundation/base.rb:40:in `block in finalize': undefined method `zero' for 9132836544:Integer (NoMethodError)

          proc { CF.release(pointer) unless pointer.address.zero }
                                                           ^^^^^
    Did you mean?  zero?
    ~/.rvm/rubies/ruby-3.1.0/bin/ruby_executable_hooks: warning: Exception in finalizer #<Proc:0x00000001099aa830 ~/src/pub/soloist/sprout-wrap/vendor/bundle/ruby/3.1.0/gems/corefoundation-0.3.4/lib/corefoundation/base.rb:40>
    ~/src/pub/soloist/sprout-wrap/vendor/bundle/ruby/3.1.0/gems/corefoundation-0.3.4/lib/corefoundation/base.rb:40:in `block in finalize': undefined method `zero' for 9132835648:Integer (NoMethodError)

          proc { CF.release(pointer) unless pointer.address.zero }
                                                           ^^^^^
    Did you mean?  zero?

Signed-off-by: James Cuzella <james.cuzella@lyraphase.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Should fix an issue while testing on Ruby 3.1.0:

    $ bundle exec chef-solo --version
        Chef Infra Client: 17.9.18
        ~/.rvm/rubies/ruby-3.1.0/bin/ruby_executable_hooks: warning: Exception in finalizer #<Proc:0x0000000109989720 ~/src/pub/soloist/
        ~/src/pub/soloist/sprout-wrap/vendor/bundle/ruby/3.1.0/gems/corefoundation-0.3.4/lib/corefoundation/base.rb:40:in `block in fina

              proc { CF.release(pointer) unless pointer.address.zero }
                                                               ^^^^^
        Did you mean?  zero?

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
