### PR TITLE
pin ffi gem to 1.15.4

### DIFF
--- a/corefoundation.gemspec
+++ b/corefoundation.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6'
 
-  s.add_runtime_dependency "ffi", ">= 1.15.0"
+  s.add_runtime_dependency "ffi", "1.15.4"
   s.add_development_dependency "rspec", ">= 3.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "chefstyle", "2.2.0"


### PR DESCRIPTION
Signed-off-by: rishichawda <rishichawda@users.noreply.github.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

With the latest version of ffi gem (v1.15.5) the build requires utilities that are part of the GNU core utilities and not included in macOS by default. This can be solved by running `brew install coreutils` in those systems to provide the `automake` utility required for compilation. However, it seems like the best way to resolve this is to pin the ffi version to 1.15.4 for now.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
