### PR TITLE
fix ruby 3.1 issue on releasing pointer

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [macos]
-        ruby: ['2.7', '3.0']
+        ruby: ['2.7', '3.0', '3.1']
     name: Unit test on Ruby ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/lib/corefoundation/array.rb
+++ b/lib/corefoundation/array.rb
@@ -49,7 +49,7 @@ module CF
       range[:location] = 0
       range[:length] = length
       callback = lambda do |value, _|
-        yield Base.typecast(value).retain
+        yield Base.typecast(value)
       end
       CF.CFArrayApplyFunction(self, range, callback, nil)
       self
@@ -79,7 +79,7 @@ module CF
     # @param [Integer] index the 0 based index of the item to retrieve. Behaviour is undefined if it is not in the range 0...size
     # @return [CF::Base] a subclass of CF::Base
     def [](index)
-      Base.typecast(CF.CFArrayGetValueAtIndex(self, index)).retain
+      Base.typecast(CF.CFArrayGetValueAtIndex(self, index))
     end
 
     # Sets object at the index

--- a/lib/corefoundation/base.rb
+++ b/lib/corefoundation/base.rb
@@ -33,11 +33,12 @@ module CF
     def initialize(pointer)
       @ptr = FFI::Pointer.new(pointer)
       ObjectSpace.define_finalizer(self, self.class.finalize(ptr))
+      CF.retain(ptr)
     end
 
     # @param [FFI::Pointer] pointer to the address of the object
     def self.finalize(pointer)
-      proc { CF.release(pointer.address) unless pointer.address.zero? }
+      proc { CF.release(pointer) unless pointer.address.zero? }
     end
 
     # Whether the instance is the CFNull singleton

--- a/lib/corefoundation/dictionary.rb
+++ b/lib/corefoundation/dictionary.rb
@@ -55,7 +55,7 @@ module CF
 
     def each
       callback = lambda do |key, value, _|
-        yield [Base.typecast(key).retain, Base.typecast(value).retain]
+        yield [Base.typecast(key), Base.typecast(value)]
       end
       CF.CFDictionaryApplyFunction(self, callback, nil)
       self
@@ -70,7 +70,7 @@ module CF
       key = CF::String.from_string(key) if key.is_a?(::String)
       self.class.check_cftype(key)
       raw = CF.CFDictionaryGetValue(self, key)
-      raw.null? ? nil : self.class.typecast(raw).retain
+      raw.null? ? nil : self.class.typecast(raw)
     end
 
     # Sets the value associated with the key, or nil


### PR DESCRIPTION
Signed-off-by: rishichawda <rishichawda@users.noreply.github.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The finaliser block on CFBase class fails on the release call when passed a pointer value. This works on ruby versions <= 3.0 but with ruby 3.1 it throws a segmentation fault. In a recent change (#31), we updated the `release` call to take `pointer.address` as in the original code before the refactor. However the change that was done in #16 was the correct code. This PR reverts back that change to correctly release the memory. This PR also adds a CFRetain call on init to prevent overreleasing an object which would lead to a segfault.

This PR also adds ruby 3.1 to the GitHub workflow.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

#35 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
