### PR TITLE
CHEF-27649 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright © 2012-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved
+Copyright © 2012-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright © 2012-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.
+Copyright © 2012-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright © 2012-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ Should work in MRI 2.6 and above and jruby. Not compatible with rubinius due to 
 ## License
 
 Released under the MIT license. See LICENSE
+
+# Copyright
+
+See [COPYRIGHT.md](./COPYRIGHT.md).


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2012-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
