### PR TITLE
fix preferences sync call

### DIFF
--- a/lib/corefoundation/preferences.rb
+++ b/lib/corefoundation/preferences.rb
@@ -18,6 +18,7 @@ module CF
   attach_function 'CFPreferencesSetValue', [:key, :value, :application_id, :username, :hostname], :void
 
   attach_function 'CFPreferencesAppSynchronize', [:application_id], :bool
+  attach_function 'CFPreferencesSynchronize', [:application_id, :username, :hostname], :void
 
   # Interface to the preference utilities from Corefoundation.framework.
   # Documentation at https://developer.apple.com/documentation/corefoundation/preferences_utilities
@@ -93,14 +94,16 @@ module CF
             arg_to_cf(username),
             arg_to_cf(hostname)
           )
+          CF.CFPreferencesSynchronize(application_id.to_cf, arg_to_cf(username), arg_to_cf(hostname))
+          true
         else
           CF.CFPreferencesSetAppValue(
             key.to_cf,
             arg_to_cf(value),
             application_id.to_cf
           )
+          CF.CFPreferencesAppSynchronize(application_id.to_cf)
         end
-        CF.CFPreferencesAppSynchronize(application_id.to_cf)
       end
 
       # Calls the {#self.set} method and raise a `PreferenceSyncFailed` error if `false` is returned.

--- a/spec/preferences_spec.rb
+++ b/spec/preferences_spec.rb
@@ -28,10 +28,17 @@ describe CF::Preferences do
   describe "self.set" do
     context "when called with valid domain/default pair" do
       context "(with username and hostname)" do
-        it "executes CF.CFPreferencesSetValue and returns true" do
+        it "executes CF.CFPreferencesSetValue and CFPreferencesSynchronize and returns true" do
           expect(CF).to receive(:CFPreferencesSetValue).with(@cf_key, @cf_value, @cf_domain, @cf_user, @cf_hostname)
-          expect(CF).to receive(:CFPreferencesAppSynchronize).with(@cf_domain).and_return(pref_sync_passed.result)
+          expect(CF).to receive(:CFPreferencesSynchronize).with(@cf_domain, @cf_user, @cf_hostname)
           expect(CF::Preferences.set(@key, @value, @domain, @user, @hostname)).to eql(true)
+        end
+      end
+      context "(with FFI::Pointer constants for username and hostname)" do
+        it "passes pointer values directly without conversion" do
+          expect(CF).to receive(:CFPreferencesSetValue).with(@cf_key, @cf_value, @cf_domain, CF::Preferences::CURRENT_USER, CF::Preferences::CURRENT_HOST)
+          expect(CF).to receive(:CFPreferencesSynchronize).with(@cf_domain, CF::Preferences::CURRENT_USER, CF::Preferences::CURRENT_HOST)
+          expect(CF::Preferences.set(@key, @value, @domain, CF::Preferences::CURRENT_USER, CF::Preferences::CURRENT_HOST)).to eql(true)
         end
       end
       context "(without username and hostname)" do
@@ -43,13 +50,6 @@ describe CF::Preferences do
       end
     end
     context "when called with invalid domain/default pair" do
-      context "(with username and hostname)" do
-        it "executes CF.CFPreferencesSetValue and returns false" do
-          expect(CF).to receive(:CFPreferencesSetValue).with(@cf_key, @cf_value, @cf_domain, @cf_user, @cf_hostname)
-          expect(CF).to receive(:CFPreferencesAppSynchronize).with(@cf_domain).and_return(pref_sync_failed.result)
-          expect(CF::Preferences.set(@key, @value, @domain, @user, @hostname)).to eql(false)
-        end
-      end
       context "(without username and hostname)" do
         it "executes CF.CFPreferencesSetAppValue and returns false" do
           expect(CF).to receive(:CFPreferencesSetAppValue).with(@cf_key, @cf_value, @cf_domain)
@@ -63,9 +63,9 @@ describe CF::Preferences do
   describe "self.set!" do
     context "when called with valid domain/default pair" do
       context "(with username and hostname)" do
-        it "executes CF.CFPreferencesSetValue and returns nil" do
+        it "executes CF.CFPreferencesSetValue and CFPreferencesSynchronize and returns nil" do
           expect(CF).to receive(:CFPreferencesSetValue).with(@cf_key, @cf_value, @cf_domain, @cf_user, @cf_hostname)
-          expect(CF).to receive(:CFPreferencesAppSynchronize).with(@cf_domain).and_return(pref_sync_passed.result)
+          expect(CF).to receive(:CFPreferencesSynchronize).with(@cf_domain, @cf_user, @cf_hostname)
           expect(CF::Preferences.set!(@key, @value, @domain, @user, @hostname)).to eql(nil)
         end
       end
@@ -78,13 +78,6 @@ describe CF::Preferences do
       end
     end
     context "when called with invalid domain/default pair" do
-      context "(with username and hostname)" do
-        it "executes CF.CFPreferencesSetValue and raises error" do
-          expect(CF).to receive(:CFPreferencesSetValue).with(@cf_key, @cf_value, @cf_domain, @cf_user, @cf_hostname)
-          expect(CF).to receive(:CFPreferencesAppSynchronize).with(@cf_domain).and_return(pref_sync_failed.result)
-          expect { CF::Preferences.set!(@key, @value, @domain, @user, @hostname) }.to raise_error CF::Exceptions::PreferenceSyncFailed
-        end
-      end
       context "(without username and hostname)" do
         it "executes CF.CFPreferencesSetAppValue and raises error" do
           expect(CF).to receive(:CFPreferencesSetAppValue).with(@cf_key, @cf_value, @cf_domain)


### PR DESCRIPTION
## Description

`Preferences.set` was failing when domain, host and user is passed. Call `CFPreferencesSynchronize` after `CF.CFPreferencesSetValue` instead of `CF.CFPreferencesAppSynchronize` to correctly write preference data. Also added a test case for the scenario that uncovered this bug in chef/chef repo to meet the minimum test coverage threshold of 90%

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
